### PR TITLE
Refactor UI layouts to use layoutComponents and add new GUI components

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-    "kiroAgent.configureMCP": "Disabled"
+    "kiroAgent.configureMCP": "Disabled",
+    "dotnet.preferCSharpExtension": true
 }

--- a/shadcnui testing/Menu/UI.cs
+++ b/shadcnui testing/Menu/UI.cs
@@ -82,6 +82,9 @@ public class UI : MonoBehaviour
     private int intSliderValue = 50;
     private float visualProgressBarValue = 0.7f;
     private int selectedVerticalTab = 0;
+    private int selectDemoCurrentSelection = 0;
+    private string inputFieldValue = "Default Input";
+    private Vector2 scrollAreaScrollPosition = Vector2.zero;
 
 
     void Start()
@@ -107,6 +110,10 @@ public class UI : MonoBehaviour
             new GUITabsComponents.TabConfig("Tabs", DrawTabsDemos),
             new GUITabsComponents.TabConfig("Text Area", DrawTextAreaDemos),
             new GUITabsComponents.TabConfig("Toggle", DrawToggleDemos),
+            new GUITabsComponents.TabConfig("Calendar", DrawCalendarDemos),
+            new GUITabsComponents.TabConfig("DropdownMenu", DrawDropdownMenuDemos),
+            new GUITabsComponents.TabConfig("Popover", DrawPopoverDemos),
+            new GUITabsComponents.TabConfig("Select", DrawSelectDemos),
             new GUITabsComponents.TabConfig("Visual", DrawVisualDemos)
         };
     }
@@ -129,10 +136,10 @@ public class UI : MonoBehaviour
         guiHelper.UpdateAnimations(showDemoWindow);
         if (guiHelper.BeginAnimatedGUI())
         {
-            currentDemoTab = guiHelper.Tabs(demoTabs.Select(tab => tab.Name).ToArray(), currentDemoTab);
+            currentDemoTab = guiHelper.Tabs(demoTabs.Select(tab => tab.Name).ToArray(), currentDemoTab, maxLines: 2);
 
             guiHelper.BeginTabContent();
-            scrollPosition = guiHelper.DrawScrollView(scrollPosition, windowRect.width - 20, windowRect.height - 40, () =>
+            scrollPosition = guiHelper.DrawScrollView(scrollPosition, () =>
             {
                 GUILayout.BeginVertical(GUILayout.Width(windowRect.width - 20), GUILayout.ExpandHeight(true));
                 if (currentDemoTab >= 0 && currentDemoTab < demoTabs.Length)
@@ -140,7 +147,7 @@ public class UI : MonoBehaviour
                     demoTabs[currentDemoTab].Content?.Invoke();
                 }
                 GUILayout.EndVertical();
-            });
+            }, GUILayout.Width(windowRect.width - 20), GUILayout.Height(windowRect.height - 40));
             guiHelper.EndTabContent();
         }
         guiHelper.EndAnimatedGUI();
@@ -491,6 +498,97 @@ public class UI : MonoBehaviour
         guiHelper.Label("Rounded Badge", LabelVariant.Default);
         guiHelper.RoundedBadge("Rounded", cornerRadius: 8f);
         guiHelper.Label("Code: guiHelper.RoundedBadge(text, cornerRadius);", LabelVariant.Muted);
+        guiHelper.HorizontalSeparator();
+
+        GUILayout.EndVertical();
+    }
+
+    void DrawCalendarDemos()
+    {
+        GUILayout.BeginVertical(GUILayout.ExpandWidth(true), GUILayout.ExpandHeight(true));
+        guiHelper.Label("Calendar", LabelVariant.Default);
+        guiHelper.MutedLabel("A component for displaying a calendar and selecting dates.");
+        guiHelper.HorizontalSeparator();
+
+        guiHelper.Calendar();
+        guiHelper.Label("Code: guiHelper.Calendar();", LabelVariant.Muted);
+        guiHelper.HorizontalSeparator();
+
+        GUILayout.EndVertical();
+    }
+
+    void DrawDropdownMenuDemos()
+    {
+        GUILayout.BeginVertical(GUILayout.ExpandWidth(true), GUILayout.ExpandHeight(true));
+        guiHelper.Label("Dropdown Menu", LabelVariant.Default);
+        guiHelper.MutedLabel("A menu that appears when a trigger is clicked.");
+        guiHelper.HorizontalSeparator();
+
+        if (guiHelper.Button("Open Dropdown Menu"))
+        {
+            guiHelper.OpenDropdownMenu();
+        }
+
+        if (guiHelper.IsDropdownMenuOpen())
+        {
+            string[] items = { "Item 1", "Item 2", "Item 3", "Item 4", "Item 5", "Item 6", "Item 7", "Item 8", "Item 9", "Item 10" };
+            guiHelper.DropdownMenu(items, (index) => {
+                Debug.Log("Selected item: " + items[index]);
+            });
+        }
+
+        guiHelper.Label("Code: guiHelper.DropdownMenu(rect, items, onItemSelected);", LabelVariant.Muted);
+        guiHelper.HorizontalSeparator();
+
+        GUILayout.EndVertical();
+    }
+
+    void DrawPopoverDemos()
+    {
+        GUILayout.BeginVertical(GUILayout.ExpandWidth(true), GUILayout.ExpandHeight(true));
+        guiHelper.Label("Popover", LabelVariant.Default);
+        guiHelper.MutedLabel("A pop-up that displays information related to an element.");
+        guiHelper.HorizontalSeparator();
+
+        if (guiHelper.Button("Open Popover"))
+        {
+            guiHelper.OpenPopover();
+        }
+
+        if (guiHelper.IsPopoverOpen())
+        {
+            guiHelper.Popover(() => {
+                guiHelper.Label("This is a popover.");
+            });
+        }
+
+        guiHelper.Label("Code: guiHelper.Popover(rect, content);", LabelVariant.Muted);
+        guiHelper.HorizontalSeparator();
+
+        GUILayout.EndVertical();
+    }
+
+    void DrawSelectDemos()
+    {
+        GUILayout.BeginVertical(GUILayout.ExpandWidth(true), GUILayout.ExpandHeight(true));
+        guiHelper.Label("Select", LabelVariant.Default);
+        guiHelper.MutedLabel("A dropdown list for selecting a value.");
+        guiHelper.HorizontalSeparator();
+
+        string[] options = { "Option 1", "Option 2", "Option 3" };
+
+        if (guiHelper.Button("Open Select"))
+        {
+            guiHelper.OpenSelect();
+        }
+
+        if (guiHelper.IsSelectOpen())
+        {
+            selectDemoCurrentSelection = guiHelper.Select(options, selectDemoCurrentSelection);
+        }
+
+        guiHelper.Label($"Selected: {options[selectDemoCurrentSelection]}");
+        guiHelper.Label("Code: guiHelper.Select(rect, options, selectedIndex);", LabelVariant.Muted);
         guiHelper.HorizontalSeparator();
 
         GUILayout.EndVertical();

--- a/shadcnui/GUIComponents/GUIAlertComponents.cs
+++ b/shadcnui/GUIComponents/GUIAlertComponents.cs
@@ -8,10 +8,12 @@ namespace shadcnui.GUIComponents
     public class GUIAlertComponents
     {
         private GUIHelper guiHelper;
+        private GUILayoutComponents layoutComponents;
 
         public GUIAlertComponents(GUIHelper helper)
         {
             guiHelper = helper;
+            layoutComponents = new GUILayoutComponents(helper);
         }
 
         public void Alert(string title, string description, AlertVariant variant = AlertVariant.Default,
@@ -20,26 +22,26 @@ namespace shadcnui.GUIComponents
             var styleManager = guiHelper.GetStyleManager();
             if (styleManager == null)
             {
-                GUILayout.BeginVertical(GUI.skin.box);
+                layoutComponents.BeginVerticalGroup(GUI.skin.box);
                 GUILayout.Label(title ?? "Alert", GUI.skin.label);
                 if (!string.IsNullOrEmpty(description))
                     GUILayout.Label(description, GUI.skin.label);
-                GUILayout.EndVertical();
+                layoutComponents.EndVerticalGroup();
                 return;
             }
 
             GUIStyle alertStyle = styleManager.GetAlertStyle(variant, type);
 
-            GUILayout.BeginVertical(alertStyle, options);
-            GUILayout.BeginHorizontal();
+            layoutComponents.BeginVerticalGroup(alertStyle, options);
+            layoutComponents.BeginHorizontalGroup();
 
             if (icon != null)
             {
                 GUILayout.Label(icon, GUILayout.Width(24 * guiHelper.uiScale), GUILayout.Height(24 * guiHelper.uiScale));
-                GUILayout.Space(8 * guiHelper.uiScale);
+                layoutComponents.AddSpace(8);
             }
 
-            GUILayout.BeginVertical();
+            layoutComponents.BeginVerticalGroup();
             if (!string.IsNullOrEmpty(title))
             {
                 GUIStyle titleStyle = styleManager.GetAlertTitleStyle(type);
@@ -59,23 +61,23 @@ namespace shadcnui.GUIComponents
                 GUILayout.Label(description, descStyle);
 #endif
             }
-            GUILayout.EndVertical();
-            GUILayout.EndHorizontal();
-            GUILayout.EndVertical();
+            layoutComponents.EndVerticalGroup();
+            layoutComponents.EndHorizontalGroup();
+            layoutComponents.EndVerticalGroup();
         }
 
         public bool DismissibleAlert(string title, string description, AlertVariant variant = AlertVariant.Default,
             AlertType type = AlertType.Info, Action onDismiss = null, params GUILayoutOption[] options)
         {
-            GUILayout.BeginVertical();
+            layoutComponents.BeginVerticalGroup();
 
             Alert(title, description, variant, type, null, options);
 
-            GUILayout.Space(4 * guiHelper.uiScale);
-            GUILayout.BeginHorizontal();
+            layoutComponents.AddSpace(4);
+            layoutComponents.BeginHorizontalGroup();
             GUILayout.FlexibleSpace();
             bool closeClicked = guiHelper.Button("X", ButtonVariant.Ghost, ButtonSize.Icon, onClick: onDismiss);
-            GUILayout.EndHorizontal();
+            layoutComponents.EndHorizontalGroup();
 
             return closeClicked;
         }
@@ -83,14 +85,14 @@ namespace shadcnui.GUIComponents
         public void AlertWithActions(string title, string description, string[] buttonTexts, Action<int> onButtonClick,
             AlertVariant variant = AlertVariant.Default, AlertType type = AlertType.Info, params GUILayoutOption[] options)
         {
-            GUILayout.BeginVertical();
+            layoutComponents.BeginVerticalGroup();
 
             Alert(title, description, variant, type, null, options);
 
             if (buttonTexts != null && buttonTexts.Length > 0)
             {
-                GUILayout.Space(8 * guiHelper.uiScale);
-                GUILayout.BeginHorizontal();
+                layoutComponents.AddSpace(8);
+                layoutComponents.BeginHorizontalGroup();
 
                 for (int i = 0; i < buttonTexts.Length; i++)
                 {
@@ -103,14 +105,14 @@ namespace shadcnui.GUIComponents
 
                     if (i < buttonTexts.Length - 1)
                     {
-                        GUILayout.Space(4 * guiHelper.uiScale);
+                        layoutComponents.AddSpace(4);
                     }
                 }
 
-                GUILayout.EndHorizontal();
+                layoutComponents.EndHorizontalGroup();
             }
 
-            GUILayout.EndVertical();
+            layoutComponents.EndVerticalGroup();
         }
 
         public void CustomAlert(string title, string description, Color backgroundColor, Color textColor, params GUILayoutOption[] options)
@@ -118,11 +120,11 @@ namespace shadcnui.GUIComponents
             var styleManager = guiHelper.GetStyleManager();
             if (styleManager == null)
             {
-                GUILayout.BeginVertical(GUI.skin.box);
+                layoutComponents.BeginVerticalGroup(GUI.skin.box);
                 GUILayout.Label(title ?? "Alert", GUI.skin.label);
                 if (!string.IsNullOrEmpty(description))
                     GUILayout.Label(description, GUI.skin.label);
-                GUILayout.EndVertical();
+                layoutComponents.EndVerticalGroup();
                 return;
             }
 
@@ -132,7 +134,7 @@ namespace shadcnui.GUIComponents
             customStyle.border = new RectOffset(guiHelper.cornerRadius, guiHelper.cornerRadius, guiHelper.cornerRadius, guiHelper.cornerRadius);
             customStyle.padding = new RectOffset(16, 16, 12, 12);
 
-            GUILayout.BeginVertical(customStyle, options);
+            layoutComponents.BeginVerticalGroup(customStyle, options);
 
             if (!string.IsNullOrEmpty(title))
             {
@@ -148,17 +150,17 @@ namespace shadcnui.GUIComponents
                 GUILayout.Label(description, descStyle);
             }
 
-            GUILayout.EndVertical();
+            layoutComponents.EndVerticalGroup();
         }
 
         public void AlertWithProgress(string title, string description, float progress, AlertVariant variant = AlertVariant.Default,
             AlertType type = AlertType.Info, params GUILayoutOption[] options)
         {
-            GUILayout.BeginVertical();
+            layoutComponents.BeginVerticalGroup();
 
             Alert(title, description, variant, type, null, options);
 
-            GUILayout.Space(8 * guiHelper.uiScale);
+            layoutComponents.AddSpace(8);
             Rect progressRect = GUILayoutUtility.GetRect(200 * guiHelper.uiScale, 6 * guiHelper.uiScale);
 
             var styleManager = guiHelper.GetStyleManager();
@@ -175,7 +177,7 @@ namespace shadcnui.GUIComponents
                 GUI.Box(fillRect, "", fillStyle);
             }
 
-            GUILayout.EndVertical();
+            layoutComponents.EndVerticalGroup();
         }
 
         public void AnimatedAlert(string title, string description, AlertVariant variant = AlertVariant.Default,
@@ -192,15 +194,14 @@ namespace shadcnui.GUIComponents
             GUI.color = originalColor;
         }
 
-
         public void AlertWithCountdown(string title, string description, float countdownTime, Action onTimeout,
             AlertVariant variant = AlertVariant.Default, AlertType type = AlertType.Info, params GUILayoutOption[] options)
         {
-            GUILayout.BeginVertical();
+            layoutComponents.BeginVerticalGroup();
 
             Alert(title, description, variant, type, null, options);
 
-            GUILayout.Space(4 * guiHelper.uiScale);
+            layoutComponents.AddSpace(4);
             int remainingSeconds = Mathf.CeilToInt(countdownTime);
             string countdownText = $"Auto-dismiss in {remainingSeconds}s";
 
@@ -213,18 +214,17 @@ namespace shadcnui.GUIComponents
                 onTimeout.Invoke();
             }
 
-            GUILayout.EndVertical();
+            layoutComponents.EndVerticalGroup();
         }
-
 
         public bool ExpandableAlert(string title, string description, string expandedContent, ref bool isExpanded,
             AlertVariant variant = AlertVariant.Default, AlertType type = AlertType.Info, params GUILayoutOption[] options)
         {
-            GUILayout.BeginVertical();
+            layoutComponents.BeginVerticalGroup();
 
             Alert(title, description, variant, type, null, options);
 
-            GUILayout.Space(4 * guiHelper.uiScale);
+            layoutComponents.AddSpace(4);
             string buttonText = isExpanded ? "Show Less" : "Show More";
             bool buttonClicked = guiHelper.Button(buttonText, ButtonVariant.Outline, ButtonSize.Small);
 
@@ -235,13 +235,13 @@ namespace shadcnui.GUIComponents
 
             if (isExpanded && !string.IsNullOrEmpty(expandedContent))
             {
-                GUILayout.Space(4 * guiHelper.uiScale);
+                layoutComponents.AddSpace(4);
                 var styleManager = guiHelper.GetStyleManager();
                 GUIStyle expandedStyle = styleManager?.GetLabelStyle(LabelVariant.Muted) ?? GUI.skin.label;
                 GUILayout.Label(expandedContent, expandedStyle);
             }
 
-            GUILayout.EndVertical();
+            layoutComponents.EndVerticalGroup();
 
             return buttonClicked;
         }
@@ -249,7 +249,7 @@ namespace shadcnui.GUIComponents
         public void AlertWithStatus(string title, string description, bool isActive, AlertVariant variant = AlertVariant.Default,
             AlertType type = AlertType.Info, params GUILayoutOption[] options)
         {
-            GUILayout.BeginHorizontal();
+            layoutComponents.BeginHorizontalGroup();
 
             Color statusColor = isActive ? Color.green : Color.gray;
             var styleManager = guiHelper.GetStyleManager();
@@ -264,14 +264,14 @@ namespace shadcnui.GUIComponents
                 statusStyle.margin = new RectOffset(0, 0, 0, 0);
 
                 GUILayout.Label("", statusStyle);
-                GUILayout.Space(8 * guiHelper.uiScale);
+                layoutComponents.AddSpace(8);
             }
 
-            GUILayout.BeginVertical();
+            layoutComponents.BeginVerticalGroup();
             Alert(title, description, variant, type, null, options);
-            GUILayout.EndVertical();
+            layoutComponents.EndVerticalGroup();
 
-            GUILayout.EndHorizontal();
+            layoutComponents.EndHorizontalGroup();
         }
 
         private Color GetProgressColor(AlertType type)

--- a/shadcnui/GUIComponents/GUIAlertComponents.cs
+++ b/shadcnui/GUIComponents/GUIAlertComponents.cs
@@ -14,7 +14,7 @@ namespace shadcnui.GUIComponents
             guiHelper = helper;
         }
 
-        public void Alert(string title, string description, AlertVariant variant = AlertVariant.Default, 
+        public void Alert(string title, string description, AlertVariant variant = AlertVariant.Default,
             AlertType type = AlertType.Info, Texture2D icon = null, params GUILayoutOption[] options)
         {
             var styleManager = guiHelper.GetStyleManager();
@@ -49,7 +49,7 @@ namespace shadcnui.GUIComponents
                 GUILayout.Label(title, titleStyle);
 #endif
             }
-            
+
             if (!string.IsNullOrEmpty(description))
             {
                 GUIStyle descStyle = styleManager.GetAlertDescriptionStyle(type);
@@ -64,19 +64,19 @@ namespace shadcnui.GUIComponents
             GUILayout.EndVertical();
         }
 
-        public bool DismissibleAlert(string title, string description, AlertVariant variant = AlertVariant.Default, 
+        public bool DismissibleAlert(string title, string description, AlertVariant variant = AlertVariant.Default,
             AlertType type = AlertType.Info, Action onDismiss = null, params GUILayoutOption[] options)
         {
             GUILayout.BeginVertical();
-            
+
             Alert(title, description, variant, type, null, options);
-            
+
             GUILayout.Space(4 * guiHelper.uiScale);
             GUILayout.BeginHorizontal();
             GUILayout.FlexibleSpace();
             bool closeClicked = guiHelper.Button("X", ButtonVariant.Ghost, ButtonSize.Icon, onClick: onDismiss);
             GUILayout.EndHorizontal();
-            
+
             return closeClicked;
         }
 
@@ -84,32 +84,32 @@ namespace shadcnui.GUIComponents
             AlertVariant variant = AlertVariant.Default, AlertType type = AlertType.Info, params GUILayoutOption[] options)
         {
             GUILayout.BeginVertical();
-            
+
             Alert(title, description, variant, type, null, options);
-            
+
             if (buttonTexts != null && buttonTexts.Length > 0)
             {
                 GUILayout.Space(8 * guiHelper.uiScale);
                 GUILayout.BeginHorizontal();
-                
+
                 for (int i = 0; i < buttonTexts.Length; i++)
                 {
                     int index = i;
-                   
-                    if (guiHelper.Button(buttonTexts[i], ButtonVariant.Outline, ButtonSize.Small)) 
+
+                    if (guiHelper.Button(buttonTexts[i], ButtonVariant.Outline, ButtonSize.Small))
                     {
                         onButtonClick?.Invoke(index);
                     }
-                    
+
                     if (i < buttonTexts.Length - 1)
                     {
                         GUILayout.Space(4 * guiHelper.uiScale);
                     }
                 }
-                
+
                 GUILayout.EndHorizontal();
             }
-            
+
             GUILayout.EndVertical();
         }
 
@@ -133,62 +133,62 @@ namespace shadcnui.GUIComponents
             customStyle.padding = new RectOffset(16, 16, 12, 12);
 
             GUILayout.BeginVertical(customStyle, options);
-            
+
             if (!string.IsNullOrEmpty(title))
             {
                 GUIStyle titleStyle = styleManager.GetAlertTitleStyle(AlertType.Info);
                 titleStyle.normal.textColor = textColor;
                 GUILayout.Label(title, titleStyle);
             }
-            
+
             if (!string.IsNullOrEmpty(description))
             {
                 GUIStyle descStyle = styleManager.GetAlertDescriptionStyle(AlertType.Info);
                 descStyle.normal.textColor = textColor;
                 GUILayout.Label(description, descStyle);
             }
-            
+
             GUILayout.EndVertical();
         }
 
-        public void AlertWithProgress(string title, string description, float progress, AlertVariant variant = AlertVariant.Default, 
+        public void AlertWithProgress(string title, string description, float progress, AlertVariant variant = AlertVariant.Default,
             AlertType type = AlertType.Info, params GUILayoutOption[] options)
         {
             GUILayout.BeginVertical();
-            
+
             Alert(title, description, variant, type, null, options);
-            
+
             GUILayout.Space(8 * guiHelper.uiScale);
             Rect progressRect = GUILayoutUtility.GetRect(200 * guiHelper.uiScale, 6 * guiHelper.uiScale);
-            
+
             var styleManager = guiHelper.GetStyleManager();
             if (styleManager != null)
             {
                 GUIStyle bgStyle = new GUIStyle(GUI.skin.box);
                 bgStyle.normal.background = styleManager.CreateSolidTexture(Color.gray);
                 GUI.Box(progressRect, "", bgStyle);
-                
-               
+
+
                 Rect fillRect = new Rect(progressRect.x, progressRect.y, progressRect.width * Mathf.Clamp01(progress), progressRect.height);
                 GUIStyle fillStyle = new GUIStyle(GUI.skin.box);
                 fillStyle.normal.background = styleManager.CreateSolidTexture(GetProgressColor(type));
                 GUI.Box(fillRect, "", fillStyle);
             }
-            
+
             GUILayout.EndVertical();
         }
 
-        public void AnimatedAlert(string title, string description, AlertVariant variant = AlertVariant.Default, 
+        public void AnimatedAlert(string title, string description, AlertVariant variant = AlertVariant.Default,
             AlertType type = AlertType.Info, params GUILayoutOption[] options)
         {
             float time = Time.time * 2f;
             float alpha = Mathf.Clamp01(time);
-            
+
             Color originalColor = GUI.color;
             GUI.color = new Color(originalColor.r, originalColor.g, originalColor.b, alpha);
-            
+
             Alert(title, description, variant, type, null, options);
-            
+
             GUI.color = originalColor;
         }
 
@@ -197,22 +197,22 @@ namespace shadcnui.GUIComponents
             AlertVariant variant = AlertVariant.Default, AlertType type = AlertType.Info, params GUILayoutOption[] options)
         {
             GUILayout.BeginVertical();
-            
+
             Alert(title, description, variant, type, null, options);
-            
+
             GUILayout.Space(4 * guiHelper.uiScale);
             int remainingSeconds = Mathf.CeilToInt(countdownTime);
             string countdownText = $"Auto-dismiss in {remainingSeconds}s";
-            
+
             var styleManager = guiHelper.GetStyleManager();
             GUIStyle countdownStyle = styleManager?.GetLabelStyle(LabelVariant.Muted) ?? GUI.skin.label;
             GUILayout.Label(countdownText, countdownStyle);
-            
+
             if (countdownTime <= 0 && onTimeout != null)
             {
                 onTimeout.Invoke();
             }
-            
+
             GUILayout.EndVertical();
         }
 
@@ -221,18 +221,18 @@ namespace shadcnui.GUIComponents
             AlertVariant variant = AlertVariant.Default, AlertType type = AlertType.Info, params GUILayoutOption[] options)
         {
             GUILayout.BeginVertical();
-            
+
             Alert(title, description, variant, type, null, options);
-            
+
             GUILayout.Space(4 * guiHelper.uiScale);
             string buttonText = isExpanded ? "Show Less" : "Show More";
             bool buttonClicked = guiHelper.Button(buttonText, ButtonVariant.Outline, ButtonSize.Small);
-            
+
             if (buttonClicked)
             {
                 isExpanded = !isExpanded;
             }
-            
+
             if (isExpanded && !string.IsNullOrEmpty(expandedContent))
             {
                 GUILayout.Space(4 * guiHelper.uiScale);
@@ -240,17 +240,17 @@ namespace shadcnui.GUIComponents
                 GUIStyle expandedStyle = styleManager?.GetLabelStyle(LabelVariant.Muted) ?? GUI.skin.label;
                 GUILayout.Label(expandedContent, expandedStyle);
             }
-            
+
             GUILayout.EndVertical();
-            
+
             return buttonClicked;
         }
 
-        public void AlertWithStatus(string title, string description, bool isActive, AlertVariant variant = AlertVariant.Default, 
+        public void AlertWithStatus(string title, string description, bool isActive, AlertVariant variant = AlertVariant.Default,
             AlertType type = AlertType.Info, params GUILayoutOption[] options)
         {
             GUILayout.BeginHorizontal();
-            
+
             Color statusColor = isActive ? Color.green : Color.gray;
             var styleManager = guiHelper.GetStyleManager();
             if (styleManager != null)
@@ -262,15 +262,15 @@ namespace shadcnui.GUIComponents
                 statusStyle.border = new RectOffset(0, 0, 0, 0);
                 statusStyle.padding = new RectOffset(0, 0, 0, 0);
                 statusStyle.margin = new RectOffset(0, 0, 0, 0);
-                
+
                 GUILayout.Label("", statusStyle);
                 GUILayout.Space(8 * guiHelper.uiScale);
             }
-            
+
             GUILayout.BeginVertical();
             Alert(title, description, variant, type, null, options);
             GUILayout.EndVertical();
-            
+
             GUILayout.EndHorizontal();
         }
 

--- a/shadcnui/GUIComponents/GUIAnimationManager.cs
+++ b/shadcnui/GUIComponents/GUIAnimationManager.cs
@@ -9,10 +9,12 @@ namespace shadcnui.GUIComponents
     public class GUIAnimationManager
     {
         private GUIHelper guiHelper;
+        private GUILayoutComponents layoutComponents;
 
         public GUIAnimationManager(GUIHelper helper)
         {
             guiHelper = helper;
+            layoutComponents = new GUILayoutComponents(helper);
         }
 
         public void UpdateAnimations(bool isOpen, ref float menuAlpha, ref float menuScale, ref float titleGlow,
@@ -89,9 +91,9 @@ namespace shadcnui.GUIComponents
 
             var styleManager = guiHelper.GetStyleManager();
 #if IL2CPP
-            GUILayout.BeginVertical(styleManager.animatedBoxStyle, (Il2CppReferenceArray<GUILayoutOption>)null);
+            layoutComponents.BeginVerticalGroup(styleManager.animatedBoxStyle, (Il2CppReferenceArray<GUILayoutOption>)null);
 #else
-            GUILayout.BeginVertical(styleManager.animatedBoxStyle);
+            layoutComponents.BeginVerticalGroup(styleManager.animatedBoxStyle);
 #endif
             GUI.color = new Color(1f, 1f, 1f, currentAlpha);
 
@@ -100,7 +102,7 @@ namespace shadcnui.GUIComponents
 
         public void EndAnimatedGUI()
         {
-            GUILayout.EndVertical();
+            layoutComponents.EndVerticalGroup();
             GUI.color = Color.white;
         }
 

--- a/shadcnui/GUIComponents/GUIAvatarComponents.cs
+++ b/shadcnui/GUIComponents/GUIAvatarComponents.cs
@@ -8,10 +8,12 @@ namespace shadcnui.GUIComponents
     public class GUIAvatarComponents
     {
         private GUIHelper guiHelper;
+        private GUILayoutComponents layoutComponents;
 
         public GUIAvatarComponents(GUIHelper helper)
         {
             guiHelper = helper;
+            layoutComponents = new GUILayoutComponents(helper);
         }
 
         public void Avatar(Texture2D image, string fallbackText, AvatarSize size = AvatarSize.Default, 
@@ -86,17 +88,17 @@ namespace shadcnui.GUIComponents
         public void AvatarWithStatus(Texture2D image, string fallbackText, bool isOnline, AvatarSize size = AvatarSize.Default, 
             AvatarShape shape = AvatarShape.Circle, params GUILayoutOption[] options)
         {
-            GUILayout.BeginHorizontal();
+            layoutComponents.BeginHorizontalGroup();
             
             Avatar(image, fallbackText, size, shape, options);
             
             if (isOnline)
             {
-                GUILayout.Space(-8 * guiHelper.uiScale);
+                layoutComponents.AddSpace(-8);
                 DrawStatusIndicator(isOnline, size);
             }
             
-            GUILayout.EndHorizontal();
+            layoutComponents.EndHorizontalGroup();
         }
 
         private void DrawStatusIndicator(bool isOnline, AvatarSize size)
@@ -123,37 +125,37 @@ namespace shadcnui.GUIComponents
         {
             if (showNameBelow)
             {
-                GUILayout.BeginVertical();
+                layoutComponents.BeginVerticalGroup();
                 
                 Avatar(image, fallbackText, size, shape, options);
                 
                 if (!string.IsNullOrEmpty(name))
                 {
-                    GUILayout.Space(4 * guiHelper.uiScale);
+                    layoutComponents.AddSpace(4);
                     var styleManager = guiHelper.GetStyleManager();
                     GUIStyle nameStyle = styleManager?.GetLabelStyle(LabelVariant.Default) ?? GUI.skin.label;
                     nameStyle.alignment = TextAnchor.MiddleCenter;
                     GUILayout.Label(name, nameStyle);
                 }
                 
-                GUILayout.EndVertical();
+                layoutComponents.EndVerticalGroup();
             }
             else
             {
-                GUILayout.BeginHorizontal();
+                layoutComponents.BeginHorizontalGroup();
                 
                 Avatar(image, fallbackText, size, shape, options);
                 
                 if (!string.IsNullOrEmpty(name))
                 {
-                    GUILayout.Space(8 * guiHelper.uiScale);
+                    layoutComponents.AddSpace(8);
                     var styleManager = guiHelper.GetStyleManager();
                     GUIStyle nameStyle = styleManager?.GetLabelStyle(LabelVariant.Default) ?? GUI.skin.label;
                     nameStyle.alignment = TextAnchor.MiddleLeft;
                     GUILayout.Label(name, nameStyle);
                 }
                 
-                GUILayout.EndHorizontal();
+                layoutComponents.EndHorizontalGroup();
             }
         }
 
@@ -211,11 +213,11 @@ namespace shadcnui.GUIComponents
             borderedStyle.alignment = TextAnchor.MiddleCenter;
             borderedStyle.padding = new RectOffset(2, 2, 2, 2);
 
-            GUILayout.BeginVertical(borderedStyle, options);
+            layoutComponents.BeginVerticalGroup(borderedStyle, options);
             {
                 Avatar(image, fallbackText, size, shape);
             }
-            GUILayout.EndVertical();
+            layoutComponents.EndVerticalGroup();
         }
 
         
@@ -273,13 +275,13 @@ namespace shadcnui.GUIComponents
         public void AvatarWithTooltip(Texture2D image, string fallbackText, string tooltip, AvatarSize size = AvatarSize.Default, 
             AvatarShape shape = AvatarShape.Circle, params GUILayoutOption[] options)
         {
-            GUILayout.BeginHorizontal();
+            layoutComponents.BeginHorizontalGroup();
             
             Avatar(image, fallbackText, size, shape, options);
             
             if (!string.IsNullOrEmpty(tooltip))
             {
-                GUILayout.Space(4 * guiHelper.uiScale);
+                layoutComponents.AddSpace(4);
                 
                 var styleManager = guiHelper.GetStyleManager();
                 GUIStyle tooltipStyle = styleManager?.GetLabelStyle(LabelVariant.Muted) ?? GUI.skin.label;
@@ -289,7 +291,7 @@ namespace shadcnui.GUIComponents
                 GUILayout.Label("?", tooltipStyle);
             }
             
-            GUILayout.EndHorizontal();
+            layoutComponents.EndHorizontalGroup();
         }
 
         public void AvatarGroup(AvatarData[] avatars, AvatarSize size = AvatarSize.Default, AvatarShape shape = AvatarShape.Circle, 
@@ -297,7 +299,7 @@ namespace shadcnui.GUIComponents
         {
             if (avatars == null || avatars.Length == 0) return;
             
-            GUILayout.BeginHorizontal();
+            layoutComponents.BeginHorizontalGroup();
             
             int visibleCount = Mathf.Min(avatars.Length, maxVisible);
             
@@ -307,7 +309,7 @@ namespace shadcnui.GUIComponents
                 
                 if (i > 0)
                 {
-                    GUILayout.Space(overlap * guiHelper.uiScale);
+                    layoutComponents.AddSpace(overlap);
                 }
                 
                 Avatar(avatar.Image, avatar.FallbackText, size, shape, options);
@@ -315,7 +317,7 @@ namespace shadcnui.GUIComponents
             
             if (avatars.Length > maxVisible)
             {
-                GUILayout.Space(overlap * guiHelper.uiScale);
+                layoutComponents.AddSpace(overlap);
                 int remainingCount = avatars.Length - maxVisible;
                 string countText = $"+{remainingCount}";
                 
@@ -331,7 +333,7 @@ namespace shadcnui.GUIComponents
 #endif
             }
             
-            GUILayout.EndHorizontal();
+            layoutComponents.EndHorizontalGroup();
         }
 
 

--- a/shadcnui/GUIComponents/GUIBadgeComponents.cs
+++ b/shadcnui/GUIComponents/GUIBadgeComponents.cs
@@ -8,10 +8,12 @@ namespace shadcnui.GUIComponents
     public class GUIBadgeComponents
     {
         private GUIHelper guiHelper;
+        private GUILayoutComponents layoutComponents;
 
         public GUIBadgeComponents(GUIHelper helper)
         {
             guiHelper = helper;
+            layoutComponents = new GUILayoutComponents(helper);
         }
 
 
@@ -58,17 +60,17 @@ namespace shadcnui.GUIComponents
         public void BadgeWithIcon(string text, Texture2D icon, BadgeVariant variant = BadgeVariant.Default, 
             BadgeSize size = BadgeSize.Default, params GUILayoutOption[] options)
         {
-            GUILayout.BeginHorizontal();
+            layoutComponents.BeginHorizontalGroup();
             
             if (icon != null)
             {
                 GUILayout.Label(icon, GUILayout.Width(16 * guiHelper.uiScale), GUILayout.Height(16 * guiHelper.uiScale));
-                GUILayout.Space(4 * guiHelper.uiScale);
+                layoutComponents.AddSpace(4);
             }
             
             Badge(text, variant, size, options);
             
-            GUILayout.EndHorizontal();
+            layoutComponents.EndHorizontalGroup();
         }
 
         public void CustomBadge(string text, Color backgroundColor, Color textColor, BadgeSize size = BadgeSize.Default,
@@ -106,7 +108,7 @@ namespace shadcnui.GUIComponents
         public void StatusBadge(string text, bool isActive, BadgeVariant variant = BadgeVariant.Default, 
             BadgeSize size = BadgeSize.Default, params GUILayoutOption[] options)
         {
-            GUILayout.BeginHorizontal();
+            layoutComponents.BeginHorizontalGroup();
             
             Color dotColor = isActive ? Color.green : Color.gray;
             var styleManager = guiHelper.GetStyleManager();
@@ -121,22 +123,22 @@ namespace shadcnui.GUIComponents
                 dotStyle.margin = new RectOffset(0, 0, 0, 0);
                 
                 GUILayout.Label("", dotStyle);
-                GUILayout.Space(4 * guiHelper.uiScale);
+                layoutComponents.AddSpace(4);
             }
             
             Badge(text, variant, size, options);
             
-            GUILayout.EndHorizontal();
+            layoutComponents.EndHorizontalGroup();
         }
 
         public bool DismissibleBadge(string text, BadgeVariant variant = BadgeVariant.Default, 
             BadgeSize size = BadgeSize.Default, Action onDismiss = null, params GUILayoutOption[] options)
         {
-            GUILayout.BeginHorizontal();
+            layoutComponents.BeginHorizontalGroup();
             
             Badge(text, variant, size, options);
             
-            GUILayout.Space(4 * guiHelper.uiScale);
+            layoutComponents.AddSpace(4);
             bool closeClicked = GUILayout.Button("×", GUILayout.Width(16 * guiHelper.uiScale), GUILayout.Height(16 * guiHelper.uiScale));
             
             if (closeClicked && onDismiss != null)
@@ -144,7 +146,7 @@ namespace shadcnui.GUIComponents
                 onDismiss.Invoke();
             }
             
-            GUILayout.EndHorizontal();
+            layoutComponents.EndHorizontalGroup();
             
             return closeClicked;
         }
@@ -152,11 +154,11 @@ namespace shadcnui.GUIComponents
         public void ProgressBadge(string text, float progress, BadgeVariant variant = BadgeVariant.Default, 
             BadgeSize size = BadgeSize.Default, params GUILayoutOption[] options)
         {
-            GUILayout.BeginVertical();
+            layoutComponents.BeginVerticalGroup();
             
             Badge(text, variant, size, options);
             
-            GUILayout.Space(2 * guiHelper.uiScale);
+            layoutComponents.AddSpace(2);
             Rect progressRect = GUILayoutUtility.GetRect(60 * guiHelper.uiScale, 4 * guiHelper.uiScale);
             
             var styleManager = guiHelper.GetStyleManager();
@@ -172,7 +174,7 @@ namespace shadcnui.GUIComponents
                 GUI.Box(fillRect, "", fillStyle);
             }
             
-            GUILayout.EndVertical();
+            layoutComponents.EndVerticalGroup();
         }
 
         public void AnimatedBadge(string text, BadgeVariant variant = BadgeVariant.Default, 
@@ -192,13 +194,13 @@ namespace shadcnui.GUIComponents
         public void BadgeWithTooltip(string text, string tooltip, BadgeVariant variant = BadgeVariant.Default, 
             BadgeSize size = BadgeSize.Default, params GUILayoutOption[] options)
         {
-            GUILayout.BeginHorizontal();
+            layoutComponents.BeginHorizontalGroup();
             
             Badge(text, variant, size, options);
             
             if (!string.IsNullOrEmpty(tooltip))
             {
-                GUILayout.Space(4 * guiHelper.uiScale);
+                layoutComponents.AddSpace(4);
                 
                 var styleManager = guiHelper.GetStyleManager();
                 GUIStyle tooltipStyle = styleManager?.GetLabelStyle(LabelVariant.Muted) ?? GUI.skin.label;
@@ -215,7 +217,7 @@ namespace shadcnui.GUIComponents
                 GUI.color = originalColor;
             }
             
-            GUILayout.EndHorizontal();
+            layoutComponents.EndHorizontalGroup();
         }
 
 
@@ -235,11 +237,11 @@ namespace shadcnui.GUIComponents
 
             if (horizontal)
             {
-                GUILayout.BeginHorizontal();
+                layoutComponents.BeginHorizontalGroup();
             }
             else
             {
-                GUILayout.BeginVertical();
+                layoutComponents.BeginVerticalGroup();
             }
 
             for (int i = 0; i < texts.Length; i++)
@@ -248,14 +250,14 @@ namespace shadcnui.GUIComponents
                 
                 if (i < texts.Length - 1)
                 {
-                    GUILayout.Space(spacing * guiHelper.uiScale);
+                    layoutComponents.AddSpace(spacing);
                 }
             }
 
             if (horizontal)
-                GUILayout.EndHorizontal();
+                layoutComponents.EndHorizontalGroup();
             else
-                GUILayout.EndVertical();
+                layoutComponents.EndVerticalGroup();
         }
 
 

--- a/shadcnui/GUIComponents/GUIButtonComponents.cs
+++ b/shadcnui/GUIComponents/GUIButtonComponents.cs
@@ -10,10 +10,12 @@ namespace shadcnui.GUIComponents
     public class GUIButtonComponents
     {
         private GUIHelper guiHelper;
+        private GUILayoutComponents layoutComponents;
 
         public GUIButtonComponents(GUIHelper helper)
         {
             guiHelper = helper;
+            layoutComponents = new GUILayoutComponents(helper);
         }
 
 
@@ -87,28 +89,28 @@ namespace shadcnui.GUIComponents
             if (horizontal)
             {
 #if IL2CPP
-                GUILayout.BeginHorizontal(GUIStyle.none, (Il2CppReferenceArray<GUILayoutOption>)null);
+                layoutComponents.BeginHorizontalGroup(GUIStyle.none, (Il2CppReferenceArray<GUILayoutOption>)null);
 #else
-                GUILayout.BeginHorizontal();
+                layoutComponents.BeginHorizontalGroup();
 #endif
             }
             else
             {
 #if IL2CPP
-                GUILayout.BeginVertical(GUIStyle.none, (Il2CppReferenceArray<GUILayoutOption>)null);
+                layoutComponents.BeginVerticalGroup(GUIStyle.none, (Il2CppReferenceArray<GUILayoutOption>)null);
 #else
-                GUILayout.BeginVertical();
+                layoutComponents.BeginVerticalGroup();
 #endif
             }
 
             drawButtons?.Invoke();
 
             if (horizontal)
-                GUILayout.EndHorizontal();
+                layoutComponents.EndHorizontalGroup();
             else
-                GUILayout.EndVertical();
+                layoutComponents.EndVerticalGroup();
 
-            GUILayout.Space(scaledSpacing);
+            layoutComponents.AddSpace(scaledSpacing);
         }
 
         public void RenderButtonSet(ButtonConfig[] buttons, bool horizontal = true, float spacing = 8f)
@@ -125,9 +127,9 @@ namespace shadcnui.GUIComponents
                     if (i < buttons.Length - 1)
                     {
                         if (horizontal)
-                            GUILayout.Space(spacing * guiHelper.uiScale);
+                            layoutComponents.AddSpace(spacing);
                         else
-                            GUILayout.Space(spacing * guiHelper.uiScale);
+                            layoutComponents.AddSpace(spacing);
                     }
                 }
             }, horizontal, 0f);

--- a/shadcnui/GUIComponents/GUICalendarComponents.cs
+++ b/shadcnui/GUIComponents/GUICalendarComponents.cs
@@ -1,0 +1,89 @@
+
+using System;
+using UnityEngine;
+
+namespace shadcnui.GUIComponents
+{
+    public class GUICalendarComponents
+    {
+        private GUIHelper guiHelper;
+        private GUILayoutComponents layoutComponents;
+        private DateTime selectedDate;
+
+        public GUICalendarComponents(GUIHelper helper)
+        {
+            this.guiHelper = helper;
+            layoutComponents = new GUILayoutComponents(helper);
+            selectedDate = DateTime.Today;
+        }
+
+        public void Calendar()
+        {
+            layoutComponents.BeginVerticalGroup(guiHelper.GetStyleManager().GetCalendarStyle(CalendarVariant.Default, CalendarSize.Default));
+
+            layoutComponents.BeginHorizontalGroup(guiHelper.GetStyleManager().calendarHeaderStyle);
+            if (GUILayout.Button("<", guiHelper.GetStyleManager().buttonGhostStyle))
+            {
+                selectedDate = selectedDate.AddMonths(-1);
+            }
+            GUILayout.Label(selectedDate.ToString("MMMM yyyy"), guiHelper.GetStyleManager().calendarTitleStyle);
+            if (GUILayout.Button(">", guiHelper.GetStyleManager().buttonGhostStyle))
+            {
+                selectedDate = selectedDate.AddMonths(1);
+            }
+            layoutComponents.EndHorizontalGroup();
+
+            layoutComponents.BeginHorizontalGroup();
+            for (int i = 0; i < 7; i++)
+            {
+                GUILayout.Label(((DayOfWeek)i).ToString().Substring(0, 2), guiHelper.GetStyleManager().calendarWeekdayStyle);
+            }
+            layoutComponents.EndHorizontalGroup();
+
+            int daysInMonth = DateTime.DaysInMonth(selectedDate.Year, selectedDate.Month);
+            int firstDayOfMonth = (int)new DateTime(selectedDate.Year, selectedDate.Month, 1).DayOfWeek;
+
+            int dayCounter = 1;
+            for (int i = 0; i < 6; i++)
+            {
+                layoutComponents.BeginHorizontalGroup();
+                for (int j = 0; j < 7; j++)
+                {
+                    if (i == 0 && j < firstDayOfMonth)
+                    {
+                        GUILayout.Label("", guiHelper.GetStyleManager().calendarDayOutsideMonthStyle);
+                    }
+                    else if (dayCounter > daysInMonth)
+                    {
+                        GUILayout.Label("", guiHelper.GetStyleManager().calendarDayOutsideMonthStyle);
+                    }
+                    else
+                    {
+                        GUIStyle dayStyle = guiHelper.GetStyleManager().calendarDayStyle;
+                        if (new DateTime(selectedDate.Year, selectedDate.Month, dayCounter) == DateTime.Today)
+                        {
+                            dayStyle = guiHelper.GetStyleManager().calendarDayTodayStyle;
+                        }
+                        if (new DateTime(selectedDate.Year, selectedDate.Month, dayCounter) == selectedDate)
+                        {
+                            dayStyle = guiHelper.GetStyleManager().calendarDaySelectedStyle;
+                        }
+
+                        if (GUILayout.Button(dayCounter.ToString(), dayStyle))
+                        {
+                            selectedDate = new DateTime(selectedDate.Year, selectedDate.Month, dayCounter);
+                        }
+                        dayCounter++;
+                    }
+                }
+                layoutComponents.EndHorizontalGroup();
+                if (dayCounter > daysInMonth)
+                {
+                    break;
+                }
+            }
+
+            layoutComponents.EndVerticalGroup();
+        }
+    }
+}

--- a/shadcnui/GUIComponents/GUICardComponents.cs
+++ b/shadcnui/GUIComponents/GUICardComponents.cs
@@ -9,10 +9,12 @@ namespace shadcnui.GUIComponents
     public class GUICardComponents
     {
         private GUIHelper guiHelper;
+        private GUILayoutComponents layoutComponents;
 
         public GUICardComponents(GUIHelper helper)
         {
             guiHelper = helper;
+            layoutComponents = new GUILayoutComponents(helper);
         }
 
         public void BeginCard(float width = -1, float height = -1)
@@ -22,12 +24,12 @@ namespace shadcnui.GUIComponents
             if (width > 0 && height > 0)
             {
 #if IL2CPP
-                GUILayout.BeginVertical(styleManager.cardStyle, (Il2CppReferenceArray<GUILayoutOption>)new GUILayoutOption[] { 
+                layoutComponents.BeginVerticalGroup(styleManager.cardStyle, (Il2CppReferenceArray<GUILayoutOption>)new GUILayoutOption[] { 
                     GUILayout.Width(width * guiHelper.uiScale), 
                     GUILayout.Height(height * guiHelper.uiScale) 
                 });
 #else
-                GUILayout.BeginVertical(styleManager.cardStyle,
+                layoutComponents.BeginVerticalGroup(styleManager.cardStyle,
                     GUILayout.Width(width * guiHelper.uiScale),
                     GUILayout.Height(height * guiHelper.uiScale));
 #endif
@@ -35,41 +37,41 @@ namespace shadcnui.GUIComponents
             else if (width > 0)
             {
 #if IL2CPP
-                GUILayout.BeginVertical(styleManager.cardStyle, (Il2CppReferenceArray<GUILayoutOption>)new GUILayoutOption[] { 
+                layoutComponents.BeginVerticalGroup(styleManager.cardStyle, (Il2CppReferenceArray<GUILayoutOption>)new GUILayoutOption[] { 
                     GUILayout.Width(width * guiHelper.uiScale) 
                 });
 #else
-                GUILayout.BeginVertical(styleManager.cardStyle, GUILayout.Width(width * guiHelper.uiScale));
+                layoutComponents.BeginVerticalGroup(styleManager.cardStyle, GUILayout.Width(width * guiHelper.uiScale));
 #endif
             }
             else
             {
 #if IL2CPP
-                GUILayout.BeginVertical(styleManager.cardStyle, (Il2CppReferenceArray<GUILayoutOption>)null);
+                layoutComponents.BeginVerticalGroup(styleManager.cardStyle, (Il2CppReferenceArray<GUILayoutOption>)null);
 #else
-                GUILayout.BeginVertical(styleManager.cardStyle);
+                layoutComponents.BeginVerticalGroup(styleManager.cardStyle);
 #endif
             }
         }
 
         public void EndCard()
         {
-            GUILayout.EndVertical();
+            layoutComponents.EndVerticalGroup();
         }
 
         public void BeginCardHeader()
         {
             var styleManager = guiHelper.GetStyleManager();
 #if IL2CPP
-            GUILayout.BeginVertical(styleManager.cardHeaderStyle, (Il2CppReferenceArray<GUILayoutOption>)null);
+            layoutComponents.BeginVerticalGroup(styleManager.cardHeaderStyle, (Il2CppReferenceArray<GUILayoutOption>)null);
 #else
-            GUILayout.BeginVertical(styleManager.cardHeaderStyle);
+            layoutComponents.BeginVerticalGroup(styleManager.cardHeaderStyle);
 #endif
         }
 
         public void EndCardHeader()
         {
-            GUILayout.EndVertical();
+            layoutComponents.EndVerticalGroup();
         }
 
         public void DrawCardTitle(string title)
@@ -88,30 +90,30 @@ namespace shadcnui.GUIComponents
         {
             var styleManager = guiHelper.GetStyleManager();
 #if IL2CPP
-            GUILayout.BeginVertical(styleManager.cardContentStyle, (Il2CppReferenceArray<GUILayoutOption>)null);
+            layoutComponents.BeginVerticalGroup(styleManager.cardContentStyle, (Il2CppReferenceArray<GUILayoutOption>)null);
 #else
-            GUILayout.BeginVertical(styleManager.cardContentStyle);
+            layoutComponents.BeginVerticalGroup(styleManager.cardContentStyle);
 #endif
         }
 
         public void EndCardContent()
         {
-            GUILayout.EndVertical();
+            layoutComponents.EndVerticalGroup();
         }
 
         public void BeginCardFooter()
         {
             var styleManager = guiHelper.GetStyleManager();
 #if IL2CPP
-            GUILayout.BeginHorizontal(styleManager.cardFooterStyle, (Il2CppReferenceArray<GUILayoutOption>)null);
+            layoutComponents.BeginHorizontalGroup(styleManager.cardFooterStyle, (Il2CppReferenceArray<GUILayoutOption>)null);
 #else
-            GUILayout.BeginHorizontal(styleManager.cardFooterStyle);
+            layoutComponents.BeginHorizontalGroup(styleManager.cardFooterStyle);
 #endif
         }
 
         public void EndCardFooter()
         {
-            GUILayout.EndHorizontal();
+            layoutComponents.EndHorizontalGroup();
         }
 
 

--- a/shadcnui/GUIComponents/GUICheckboxComponents.cs
+++ b/shadcnui/GUIComponents/GUICheckboxComponents.cs
@@ -8,10 +8,12 @@ namespace shadcnui.GUIComponents
     public class GUICheckboxComponents
     {
         private GUIHelper guiHelper;
+        private GUILayoutComponents layoutComponents;
 
         public GUICheckboxComponents(GUIHelper helper)
         {
             guiHelper = helper;
+            layoutComponents = new GUILayoutComponents(helper);
         }
 
 
@@ -80,7 +82,7 @@ namespace shadcnui.GUIComponents
         public bool CheckboxWithLabel(string label, ref bool value, CheckboxVariant variant = CheckboxVariant.Default,
             CheckboxSize size = CheckboxSize.Default, Action<bool> onToggle = null, bool disabled = false)
         {
-            GUILayout.BeginHorizontal();
+            layoutComponents.BeginHorizontalGroup();
 
             bool newValue = Checkbox("", value, variant, size, onToggle, disabled, GUILayout.Width(20 * guiHelper.uiScale));
 
@@ -106,7 +108,7 @@ namespace shadcnui.GUIComponents
 #endif
 
             GUI.color = originalColor;
-            GUILayout.EndHorizontal();
+            layoutComponents.EndHorizontalGroup();
 
             return newValue;
         }
@@ -126,11 +128,11 @@ namespace shadcnui.GUIComponents
 
             if (horizontal)
             {
-                GUILayout.BeginHorizontal();
+                layoutComponents.BeginHorizontalGroup();
             }
             else
             {
-                GUILayout.BeginVertical();
+                layoutComponents.BeginVerticalGroup();
             }
 
             for (int i = 0; i < labels.Length; i++)
@@ -145,14 +147,14 @@ namespace shadcnui.GUIComponents
 
                 if (i < labels.Length - 1)
                 {
-                    GUILayout.Space(spacing * guiHelper.uiScale);
+                    layoutComponents.AddSpace(spacing);
                 }
             }
 
             if (horizontal)
-                GUILayout.EndHorizontal();
+                layoutComponents.EndHorizontalGroup();
             else
-                GUILayout.EndVertical();
+                layoutComponents.EndVerticalGroup();
 
             return newValues;
         }
@@ -202,7 +204,7 @@ namespace shadcnui.GUIComponents
         public bool CheckboxWithIcon(string text, ref bool value, Texture2D icon, CheckboxVariant variant = CheckboxVariant.Default,
             CheckboxSize size = CheckboxSize.Default, Action<bool> onToggle = null, bool disabled = false)
         {
-            GUILayout.BeginHorizontal();
+            layoutComponents.BeginHorizontalGroup();
 
             bool newValue = Checkbox("", value, variant, size, onToggle, disabled, GUILayout.Width(20 * guiHelper.uiScale));
             if (newValue != value)
@@ -214,7 +216,7 @@ namespace shadcnui.GUIComponents
             if (icon != null)
             {
                 GUILayout.Label(icon, GUILayout.Width(16 * guiHelper.uiScale), GUILayout.Height(16 * guiHelper.uiScale));
-                GUILayout.Space(4 * guiHelper.uiScale);
+                layoutComponents.AddSpace(4);
             }
 
             var styleManager = guiHelper.GetStyleManager();
@@ -233,7 +235,7 @@ namespace shadcnui.GUIComponents
 #endif
 
             GUI.color = originalColor;
-            GUILayout.EndHorizontal();
+            layoutComponents.EndHorizontalGroup();
 
             return newValue;
         }
@@ -243,7 +245,7 @@ namespace shadcnui.GUIComponents
             CheckboxVariant variant = CheckboxVariant.Default, CheckboxSize size = CheckboxSize.Default,
             Action<bool> onToggle = null, bool disabled = false)
         {
-            GUILayout.BeginVertical();
+            layoutComponents.BeginVerticalGroup();
 
             bool newValue = CheckboxWithLabel(label, ref value, variant, size, onToggle, disabled);
 
@@ -258,7 +260,7 @@ namespace shadcnui.GUIComponents
                     GUI.color = new Color(originalColor.r, originalColor.g, originalColor.b, 0.7f);
                 }
 
-                GUILayout.Space(2 * guiHelper.uiScale);
+                layoutComponents.AddSpace(2);
 #if IL2CPP
                 GUILayout.Label(description, descStyle, (Il2CppReferenceArray<GUILayoutOption>)null);
 #else
@@ -268,7 +270,7 @@ namespace shadcnui.GUIComponents
                 GUI.color = originalColor;
             }
 
-            GUILayout.EndVertical();
+            layoutComponents.EndVerticalGroup();
 
             return newValue;
         }
@@ -277,7 +279,7 @@ namespace shadcnui.GUIComponents
             CheckboxVariant variant = CheckboxVariant.Default, CheckboxSize size = CheckboxSize.Default,
             Action<bool> onToggle = null, bool disabled = false)
         {
-            GUILayout.BeginVertical();
+            layoutComponents.BeginVerticalGroup();
 
             bool newValue = CheckboxWithLabel(text, ref value, variant, size, onToggle, disabled);
 
@@ -286,7 +288,7 @@ namespace shadcnui.GUIComponents
                 var styleManager = guiHelper.GetStyleManager();
                 GUIStyle errorStyle = styleManager?.GetLabelStyle(LabelVariant.Destructive) ?? GUI.skin.label;
 
-                GUILayout.Space(2 * guiHelper.uiScale);
+                layoutComponents.AddSpace(2);
 #if IL2CPP
                 GUILayout.Label(validationMessage, errorStyle, (Il2CppReferenceArray<GUILayoutOption>)null);
 #else
@@ -294,7 +296,7 @@ namespace shadcnui.GUIComponents
 #endif
             }
 
-            GUILayout.EndVertical();
+            layoutComponents.EndVerticalGroup();
 
             return newValue;
         }
@@ -302,13 +304,13 @@ namespace shadcnui.GUIComponents
         public bool CheckboxWithTooltip(string text, ref bool value, string tooltip, CheckboxVariant variant = CheckboxVariant.Default,
             CheckboxSize size = CheckboxSize.Default, Action<bool> onToggle = null, bool disabled = false)
         {
-            GUILayout.BeginHorizontal();
+            layoutComponents.BeginHorizontalGroup();
 
             bool newValue = CheckboxWithLabel(text, ref value, variant, size, onToggle, disabled);
 
             if (!string.IsNullOrEmpty(tooltip))
             {
-                GUILayout.Space(4 * guiHelper.uiScale);
+                layoutComponents.AddSpace(4);
 
                 var styleManager = guiHelper.GetStyleManager();
                 GUIStyle tooltipStyle = styleManager?.GetLabelStyle(LabelVariant.Muted) ?? GUI.skin.label;
@@ -325,7 +327,7 @@ namespace shadcnui.GUIComponents
                 GUI.color = originalColor;
             }
 
-            GUILayout.EndHorizontal();
+            layoutComponents.EndHorizontalGroup();
 
             return newValue;
         }

--- a/shadcnui/GUIComponents/GUIDropdownMenuComponents.cs
+++ b/shadcnui/GUIComponents/GUIDropdownMenuComponents.cs
@@ -1,0 +1,52 @@
+
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace shadcnui.GUIComponents
+{
+    public class GUIDropdownMenuComponents
+    {
+        private GUIHelper guiHelper;
+        private GUILayoutComponents layoutComponents;
+        private bool isOpen;
+        private Vector2 scrollPosition;
+
+        public GUIDropdownMenuComponents(GUIHelper helper)
+        {
+            this.guiHelper = helper;
+            layoutComponents = new GUILayoutComponents(helper);
+        }
+
+        public bool IsOpen => isOpen;
+
+        public void Open()
+        {
+            isOpen = true;
+        }
+
+        public void Close()
+        {
+            isOpen = false;
+        }
+
+        public void DropdownMenu(string[] items, Action<int> onItemSelected)
+        {
+            if (!isOpen) return;
+
+            layoutComponents.BeginVerticalGroup(guiHelper.GetStyleManager().dropdownMenuContentStyle, GUILayout.ExpandWidth(true), GUILayout.MinHeight(0), GUILayout.MaxHeight(200));
+            scrollPosition = layoutComponents.DrawScrollView(scrollPosition, () =>
+            {
+                for (int i = 0; i < items.Length; i++)
+                {
+                    if (GUILayout.Button(items[i], guiHelper.GetStyleManager().dropdownMenuItemStyle))
+                    {
+                        onItemSelected?.Invoke(i);
+                        Close();
+                    }
+                }
+            }, GUILayout.ExpandWidth(true), GUILayout.ExpandHeight(true));
+            layoutComponents.EndVerticalGroup();
+        }
+    }
+}

--- a/shadcnui/GUIComponents/GUIInputComponents.cs
+++ b/shadcnui/GUIComponents/GUIInputComponents.cs
@@ -9,11 +9,13 @@ namespace shadcnui.GUIComponents
     public class GUIInputComponents
     {
         private GUIHelper guiHelper;
+        private GUILayoutComponents layoutComponents;
         private static float horizontalPadding = 10f;
 
         public GUIInputComponents(GUIHelper helper)
         {
             guiHelper = helper;
+            layoutComponents = new GUILayoutComponents(helper);
         }
 
 
@@ -126,7 +128,7 @@ namespace shadcnui.GUIComponents
             bool disabled = false, int inputWidth = -1, Action<string> onChange = null)
         {
             DrawLabel(label, labelVariant, -1, disabled);
-            GUILayout.Space(4);
+            layoutComponents.AddSpace(4);
             return DrawInput(value, placeholder, inputVariant, disabled, false, inputWidth, onChange);
         }
 
@@ -145,7 +147,7 @@ namespace shadcnui.GUIComponents
             if (!string.IsNullOrEmpty(label))
             {
                 DrawLabel(label, LabelVariant.Default, -1, disabled);
-                GUILayout.Space(4);
+                layoutComponents.AddSpace(4);
             }
 
             GUIStyle passwordStyle = styleManager.GetPasswordFieldStyle();
@@ -168,7 +170,7 @@ namespace shadcnui.GUIComponents
 #endif
 
             GUI.color = originalColor;
-            GUILayout.Space(guiHelper.controlSpacing);
+            layoutComponents.AddSpace(guiHelper.controlSpacing);
 
 
             if (newValue != value && !disabled && onChange != null)
@@ -197,7 +199,7 @@ namespace shadcnui.GUIComponents
             if (!string.IsNullOrEmpty(label))
             {
                 DrawLabel(label, LabelVariant.Default, -1, disabled);
-                GUILayout.Space(4);
+                layoutComponents.AddSpace(4);
             }
 
             GUIStyle textAreaStyle = styleManager.GetTextAreaStyle(TextAreaVariant.Default, focused);
@@ -220,7 +222,7 @@ namespace shadcnui.GUIComponents
 #endif
 
             GUI.color = originalColor;
-            GUILayout.Space(guiHelper.controlSpacing);
+            layoutComponents.AddSpace(guiHelper.controlSpacing);
 
 
             if (newValue != value && !disabled && onChange != null)
@@ -235,7 +237,7 @@ namespace shadcnui.GUIComponents
         public void DrawSectionHeader(string title)
         {
             var styleManager = guiHelper.GetStyleManager();
-            GUILayout.Space(guiHelper.controlSpacing * 0.5f);
+            layoutComponents.AddSpace(guiHelper.controlSpacing * 0.5f);
 #if IL2CPP
             GUILayout.Label(title, styleManager?.sectionHeaderStyle ?? GUI.skin.label, (Il2CppReferenceArray<GUILayoutOption>)null);
 #else

--- a/shadcnui/GUIComponents/GUILayoutComponents.cs
+++ b/shadcnui/GUIComponents/GUILayoutComponents.cs
@@ -15,17 +15,13 @@ namespace shadcnui.GUIComponents
             guiHelper = helper;
         }
 
-        public Vector2 DrawScrollView(Vector2 scrollPosition, float width, float height, Action drawContent)
+        public Vector2 DrawScrollView(Vector2 scrollPosition, Action drawContent, params GUILayoutOption[] options)
         {
 #if IL2CPP
             scrollPosition = GUILayout.BeginScrollView(scrollPosition, 
-                (Il2CppReferenceArray<GUILayoutOption>)new GUILayoutOption[] { 
-                    GUILayout.Width(width * guiHelper.uiScale), 
-                    GUILayout.Height(height * guiHelper.uiScale) 
-                });
+                (Il2CppReferenceArray<GUILayoutOption>)options);
 #else
-            scrollPosition = GUILayout.BeginScrollView(scrollPosition,
-                GUILayout.Width(width * guiHelper.uiScale), GUILayout.Height(height * guiHelper.uiScale));
+            scrollPosition = GUILayout.BeginScrollView(scrollPosition, options);
 #endif
             drawContent?.Invoke();
             GUILayout.EndScrollView();
@@ -38,6 +34,15 @@ namespace shadcnui.GUIComponents
             GUILayout.BeginHorizontal(GUIStyle.none, (Il2CppReferenceArray<GUILayoutOption>)null);
 #else
             GUILayout.BeginHorizontal();
+#endif
+        }
+
+        public void BeginHorizontalGroup(GUIStyle style, params GUILayoutOption[] options)
+        {
+#if IL2CPP
+            GUILayout.BeginHorizontal(style, (Il2CppReferenceArray<GUILayoutOption>)options);
+#else
+            GUILayout.BeginHorizontal(style, options);
 #endif
         }
 
@@ -56,6 +61,15 @@ namespace shadcnui.GUIComponents
 #endif
         }
 
+        public void BeginVerticalGroup(GUIStyle style, params GUILayoutOption[] options)
+        {
+#if IL2CPP
+            GUILayout.BeginVertical(style, (Il2CppReferenceArray<GUILayoutOption>)options);
+#else
+            GUILayout.BeginVertical(style, options);
+#endif
+        }
+
         public void EndVerticalGroup()
         {
             GUILayout.EndVertical();
@@ -65,5 +79,6 @@ namespace shadcnui.GUIComponents
         {
             GUILayout.Space(pixels * guiHelper.uiScale);
         }
+
     }
 }

--- a/shadcnui/GUIComponents/GUIPopoverComponents.cs
+++ b/shadcnui/GUIComponents/GUIPopoverComponents.cs
@@ -1,0 +1,38 @@
+
+using System;
+using UnityEngine;
+
+namespace shadcnui.GUIComponents
+{
+    public class GUIPopoverComponents
+    {
+        private GUIHelper guiHelper;
+        private bool isOpen;
+
+        public GUIPopoverComponents(GUIHelper helper)
+        {
+            this.guiHelper = helper;
+        }
+
+        public bool IsOpen => isOpen;
+
+        public void Open()
+        {
+            isOpen = true;
+        }
+
+        public void Close()
+        {
+            isOpen = false;
+        }
+
+        public void Popover(Action content)
+        {
+            if (!isOpen) return;
+
+            GUILayout.BeginVertical(guiHelper.GetStyleManager().popoverContentStyle, GUILayout.MaxWidth(300), GUILayout.MaxHeight(200));
+            content?.Invoke();
+            GUILayout.EndVertical();
+        }
+    }
+}

--- a/shadcnui/GUIComponents/GUIProgressComponents.cs
+++ b/shadcnui/GUIComponents/GUIProgressComponents.cs
@@ -7,10 +7,12 @@ namespace shadcnui.GUIComponents
     public class GUIProgressComponents
     {
         private GUIHelper guiHelper;
+        private GUILayoutComponents layoutComponents;
 
         public GUIProgressComponents(GUIHelper helper)
         {
             guiHelper = helper;
+            layoutComponents = new GUILayoutComponents(helper);
         }
         public void Progress(float value, float width = -1, float height = -1, params GUILayoutOption[] options)
         {
@@ -98,7 +100,7 @@ namespace shadcnui.GUIComponents
            
             if (!string.IsNullOrEmpty(label))
             {
-                GUILayout.BeginHorizontal();
+                layoutComponents.BeginHorizontalGroup();
                 GUILayout.Label(label, styleManager.GetLabelStyle(LabelVariant.Default));
 
                 if (showPercentage)
@@ -108,8 +110,8 @@ namespace shadcnui.GUIComponents
                     GUILayout.Label(percentText, styleManager.GetLabelStyle(LabelVariant.Muted));
                 }
 
-                GUILayout.EndHorizontal();
-                GUILayout.Space(4 * guiHelper.uiScale);
+                layoutComponents.EndHorizontalGroup();
+                layoutComponents.AddSpace(4);
             }
 
            

--- a/shadcnui/GUIComponents/GUISelectComponents.cs
+++ b/shadcnui/GUIComponents/GUISelectComponents.cs
@@ -1,0 +1,64 @@
+
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace shadcnui.GUIComponents
+{
+    public class GUISelectComponents
+    {
+        private GUIHelper guiHelper;
+        private GUILayoutComponents layoutComponents;
+        private bool isOpen;
+        private int selectedIndex;
+        private Vector2 scrollPosition;
+
+        public GUISelectComponents(GUIHelper helper)
+        {
+            this.guiHelper = helper;
+            layoutComponents = new GUILayoutComponents(helper);
+        }
+
+        public bool IsOpen => isOpen;
+
+        public void Open()
+        {
+            isOpen = true;
+        }
+
+        public void Close()
+        {
+            isOpen = false;
+        }
+
+        public int Select(string[] items, int selectedIndex)
+        {
+            if (!isOpen) return selectedIndex;
+
+            GUILayout.BeginVertical(guiHelper.GetStyleManager().GetSelectStyle(SelectVariant.Default, SelectSize.Default), GUILayout.MaxWidth(300), GUILayout.MaxHeight(200));
+
+            scrollPosition = layoutComponents.DrawScrollView(scrollPosition, () =>
+            {
+                for (int i = 0; i < items.Length; i++)
+                {
+                    GUIStyle itemStyle = guiHelper.GetStyleManager().GetSelectItemStyle();
+                    if (i == selectedIndex)
+                    {
+                        itemStyle = new GUIStyle(itemStyle);
+                        itemStyle.normal.textColor = Color.blue;
+                    }
+
+                    if (GUILayout.Button(items[i], itemStyle))
+                    {
+                        selectedIndex = i;
+                        Close();
+                    }
+                }
+            }, GUILayout.ExpandWidth(true), GUILayout.MinHeight(0), GUILayout.MaxHeight(200));
+
+            GUILayout.EndVertical();
+
+            return selectedIndex;
+        }
+    }
+}

--- a/shadcnui/GUIComponents/GUISkeletonComponents.cs
+++ b/shadcnui/GUIComponents/GUISkeletonComponents.cs
@@ -8,14 +8,16 @@ namespace shadcnui.GUIComponents
     public class GUISkeletonComponents
     {
         private GUIHelper guiHelper;
+        private GUILayoutComponents layoutComponents;
 
         public GUISkeletonComponents(GUIHelper helper)
         {
             guiHelper = helper;
+            layoutComponents = new GUILayoutComponents(helper);
         }
 
-        public void Skeleton(float width, float height, SkeletonVariant variant = SkeletonVariant.Default, 
-            SkeletonSize size = SkeletonSize.Default, params GUILayoutOption[] options)
+        public void Skeleton(float width, float height, SkeletonVariant variant, 
+            SkeletonSize size, params GUILayoutOption[] options)
         {
             var styleManager = guiHelper.GetStyleManager();
             if (styleManager == null)
@@ -40,29 +42,10 @@ namespace shadcnui.GUIComponents
 #endif
         }
 
-        public void Skeleton(Rect rect, SkeletonVariant variant = SkeletonVariant.Default, SkeletonSize size = SkeletonSize.Default)
-        {
-            var styleManager = guiHelper.GetStyleManager();
-            if (styleManager == null)
-            {
-                GUI.Box(rect, "");
-                return;
-            }
+        
 
-            GUIStyle skeletonStyle = styleManager.GetSkeletonStyle(variant, size);
-
-            Rect scaledRect = new Rect(
-                rect.x * guiHelper.uiScale,
-                rect.y * guiHelper.uiScale,
-                rect.width * guiHelper.uiScale,
-                rect.height * guiHelper.uiScale
-            );
-
-            GUI.Box(scaledRect, "", skeletonStyle);
-        }
-
-        public void AnimatedSkeleton(float width, float height, SkeletonVariant variant = SkeletonVariant.Default, 
-            SkeletonSize size = SkeletonSize.Default, params GUILayoutOption[] options)
+        public void AnimatedSkeleton(float width, float height, SkeletonVariant variant, 
+            SkeletonSize size, params GUILayoutOption[] options)
         {
             float time = Time.time * 2f;
             float alpha = (Mathf.Sin(time) + 1f) * 0.5f * 0.3f + 0.7f;
@@ -75,8 +58,8 @@ namespace shadcnui.GUIComponents
             GUI.color = originalColor;
         }
 
-        public void ShimmerSkeleton(float width, float height, SkeletonVariant variant = SkeletonVariant.Default, 
-            SkeletonSize size = SkeletonSize.Default, params GUILayoutOption[] options)
+        public void ShimmerSkeleton(float width, float height, SkeletonVariant variant, 
+            SkeletonSize size, params GUILayoutOption[] options)
         {
             var styleManager = guiHelper.GetStyleManager();
             if (styleManager == null)
@@ -110,7 +93,7 @@ namespace shadcnui.GUIComponents
         }
 
         public void CustomSkeleton(float width, float height, Color backgroundColor, Color shimmerColor, 
-            SkeletonVariant variant = SkeletonVariant.Default, SkeletonSize size = SkeletonSize.Default, 
+            SkeletonVariant variant, SkeletonSize size, 
             params GUILayoutOption[] options)
         {
             var styleManager = guiHelper.GetStyleManager();
@@ -138,120 +121,99 @@ namespace shadcnui.GUIComponents
 #endif
         }
 
-        public void SkeletonText(int lineCount, float lineHeight = 20f, SkeletonVariant variant = SkeletonVariant.Default, 
-            SkeletonSize size = SkeletonSize.Default, params GUILayoutOption[] options)
+        public void SkeletonText(float width, int lines, params GUILayoutOption[] options)
         {
-            GUILayout.BeginVertical();
-            
-            for (int i = 0; i < lineCount; i++)
+            layoutComponents.BeginVerticalGroup();
+            for (int i = 0; i < lines; i++)
             {
-                float lineWidth = 200f;
-                if (i == lineCount - 1 && lineCount > 1)
+                float currentWidth = width * guiHelper.uiScale;
+                if (i == lines - 1 && lines > 1) currentWidth *= 0.7f;
+
+                Skeleton(currentWidth, guiHelper.fontSize * 1.2f, SkeletonVariant.Default, SkeletonSize.Default, options);
+                if (i < lines - 1)
                 {
-                    lineWidth = 120f;
-                }
-                else if (i % 3 == 0)
-                {
-                    lineWidth = 180f;
-                }
-                
-                Skeleton(lineWidth, lineHeight, variant, size, options);
-                
-                if (i < lineCount - 1)
-                {
-                    GUILayout.Space(4 * guiHelper.uiScale);
+                    layoutComponents.AddSpace(guiHelper.fontSize * 0.3f);
                 }
             }
-            
-            GUILayout.EndVertical();
+            layoutComponents.EndVerticalGroup();
         }
 
-        public void SkeletonAvatar(float size, SkeletonVariant variant = SkeletonVariant.Circular, 
+        public void SkeletonAvatar(float size, SkeletonVariant variant, 
             params GUILayoutOption[] options)
         {
-            Skeleton(size, size, variant, SkeletonSize.Default, options);
+            Skeleton((float)size, (float)size, variant, SkeletonSize.Default, options ?? new GUILayoutOption[0]);
         }
 
-        public void SkeletonButton(float width = 120f, float height = 36f, SkeletonVariant variant = SkeletonVariant.Rounded, 
-            SkeletonSize size = SkeletonSize.Default, params GUILayoutOption[] options)
+        public void SkeletonButton(float width, float height, SkeletonVariant variant, 
+            SkeletonSize size, params GUILayoutOption[] options)
         {
-            Skeleton(width, height, variant, size, options);
+            Skeleton((float)width, (float)height, variant, size, options ?? new GUILayoutOption[0]);
         }
 
-        public void SkeletonCard(float width = 300f, float height = 200f, SkeletonVariant variant = SkeletonVariant.Rounded, 
-            SkeletonSize size = SkeletonSize.Default, params GUILayoutOption[] options)
+        public void SkeletonCard(float width, float height, bool includeHeader, bool includeFooter, params GUILayoutOption[] options)
         {
-            GUILayout.BeginVertical();
-            
-            Skeleton(width, 40f, variant, size, options);
-            GUILayout.Space(8 * guiHelper.uiScale);
-            
-            SkeletonText(3, 16f, variant, size, options);
-            GUILayout.Space(8 * guiHelper.uiScale);
-            
-            Skeleton(width * 0.6f, 30f, variant, size, options);
-            
-            GUILayout.EndVertical();
-        }
+            layoutComponents.BeginVerticalGroup();
 
-        public void SkeletonTable(int rowCount, int columnCount, float cellWidth = 100f, float cellHeight = 30f, 
-            SkeletonVariant variant = SkeletonVariant.Default, SkeletonSize size = SkeletonSize.Default, 
-            params GUILayoutOption[] options)
-        {
-            GUILayout.BeginVertical();
-            
-            for (int row = 0; row < rowCount; row++)
+            if (includeHeader)
             {
-                GUILayout.BeginHorizontal();
-                
-                for (int col = 0; col < columnCount; col++)
+                layoutComponents.BeginVerticalGroup();
+                SkeletonText(width * 0.8f, 1);
+                layoutComponents.AddSpace(guiHelper.fontSize * 0.3f);
+                SkeletonText(width * 0.6f, 1);
+                layoutComponents.EndVerticalGroup();
+                layoutComponents.AddSpace(guiHelper.controlSpacing);
+            }
+
+            SkeletonText(width, 3);
+
+            if (includeFooter)
+            {
+                layoutComponents.AddSpace(guiHelper.controlSpacing);
+                layoutComponents.BeginHorizontalGroup();
+                Skeleton(width * 0.3f, guiHelper.fontSize * 1.5f, SkeletonVariant.Default, SkeletonSize.Default, options);
+                layoutComponents.AddSpace(guiHelper.controlSpacing);
+                Skeleton(width * 0.3f, guiHelper.fontSize * 1.5f, SkeletonVariant.Default, SkeletonSize.Default, options);
+                layoutComponents.EndHorizontalGroup();
+            }
+
+            layoutComponents.EndVerticalGroup();
+        }
+
+        public void SkeletonTable(float width, int rows, int columns, float cellHeight, float cellSpacing, params GUILayoutOption[] options)
+        {
+            layoutComponents.BeginVerticalGroup();
+            for (int r = 0; r < rows; r++)
+            {
+                layoutComponents.BeginHorizontalGroup();
+                for (int c = 0; c < columns; c++)
                 {
-                    Skeleton(cellWidth, cellHeight, variant, size, options);
-                    
-                    if (col < columnCount - 1)
+                    Skeleton(width / columns - cellSpacing, cellHeight, SkeletonVariant.Default, SkeletonSize.Default, options);
+                    if (c < columns - 1)
                     {
-                        GUILayout.Space(4 * guiHelper.uiScale);
+                        layoutComponents.AddSpace(cellSpacing);
                     }
                 }
-                
-                GUILayout.EndHorizontal();
-                
-                if (row < rowCount - 1)
+                layoutComponents.EndHorizontalGroup();
+                if (r < rows - 1)
                 {
-                    GUILayout.Space(4 * guiHelper.uiScale);
+                    layoutComponents.AddSpace(cellSpacing);
                 }
             }
-            
-            GUILayout.EndVertical();
+            layoutComponents.EndVerticalGroup();
         }
 
-        public void SkeletonList(int itemCount, float itemHeight = 60f, SkeletonVariant variant = SkeletonVariant.Rounded, 
-            SkeletonSize size = SkeletonSize.Default, params GUILayoutOption[] options)
+        public void SkeletonList(float itemWidth, float itemHeight, int itemCount, float spacing, params GUILayoutOption[] options)
         {
-            GUILayout.BeginVertical();
-            
+            layoutComponents.BeginVerticalGroup();
             for (int i = 0; i < itemCount; i++)
             {
-                GUILayout.BeginHorizontal();
-                
-                SkeletonAvatar(40f, variant, options);
-                GUILayout.Space(8 * guiHelper.uiScale);
-                
-                GUILayout.BeginVertical();
-                Skeleton(150f, 16f, variant, size, options);
-                GUILayout.Space(4 * guiHelper.uiScale);
-                Skeleton(100f, 12f, variant, size, options);
-                GUILayout.EndVertical();
-                
-                GUILayout.EndHorizontal();
-                
+                Skeleton(itemWidth, itemHeight, SkeletonVariant.Default, SkeletonSize.Default, options);
                 if (i < itemCount - 1)
                 {
-                    GUILayout.Space(8 * guiHelper.uiScale);
+                    layoutComponents.AddSpace(spacing);
                 }
             }
-            
-            GUILayout.EndVertical();
+            layoutComponents.EndVerticalGroup();
         }
 
         public void CustomShapeSkeleton(float width, float height, float cornerRadius, Color backgroundColor, 
@@ -287,8 +249,8 @@ namespace shadcnui.GUIComponents
 #endif
         }
 
-        public void SkeletonWithProgress(float width, float height, float progress, SkeletonVariant variant = SkeletonVariant.Default, 
-            SkeletonSize size = SkeletonSize.Default, params GUILayoutOption[] options)
+        public void SkeletonWithProgress(float width, float height, float progress, SkeletonVariant variant, 
+            SkeletonSize size, params GUILayoutOption[] options)
         {
             GUILayout.BeginVertical();
             
@@ -313,8 +275,8 @@ namespace shadcnui.GUIComponents
             GUILayout.EndVertical();
         }
 
-        public void FadeSkeleton(float width, float height, float fadeTime, SkeletonVariant variant = SkeletonVariant.Default, 
-            SkeletonSize size = SkeletonSize.Default, params GUILayoutOption[] options)
+        public void FadeSkeleton(float width, float height, float fadeTime, SkeletonVariant variant, 
+            SkeletonSize size, params GUILayoutOption[] options)
         {
             float time = Time.time;
             float alpha = Mathf.Clamp01(1f - (time / fadeTime));

--- a/shadcnui/GUIComponents/GUISliderComponents.cs
+++ b/shadcnui/GUIComponents/GUISliderComponents.cs
@@ -9,10 +9,12 @@ namespace shadcnui.GUIComponents
     public class GUISliderComponents
     {
         private GUIHelper guiHelper;
+        private GUILayoutComponents layoutComponents;
 
         public GUISliderComponents(GUIHelper helper)
         {
             guiHelper = helper;
+            layoutComponents = new GUILayoutComponents(helper);
         }
 
         public void DrawSlider(float windowWidth, string label, ref float value, float minValue, float maxValue)
@@ -25,7 +27,7 @@ namespace shadcnui.GUIComponents
             GUILayout.Label(label + ": " + value.ToString("F2"), styleManager.glowLabelStyle);
             value = GUILayout.HorizontalSlider(value, minValue, maxValue);
 #endif
-            GUILayout.Space(guiHelper.controlSpacing);
+            layoutComponents.AddSpace(guiHelper.controlSpacing);
         }
 
         public void DrawIntSlider(float windowWidth, string label, ref int value, int minValue, int maxValue)
@@ -38,7 +40,7 @@ namespace shadcnui.GUIComponents
             GUILayout.Label(label + ": " + value.ToString(), styleManager.glowLabelStyle);
             value = (int)GUILayout.HorizontalSlider(value, minValue, maxValue);
 #endif
-            GUILayout.Space(guiHelper.controlSpacing);
+            layoutComponents.AddSpace(guiHelper.controlSpacing);
         }
 
     }

--- a/shadcnui/GUIComponents/GUIStyleManager.cs
+++ b/shadcnui/GUIComponents/GUIStyleManager.cs
@@ -269,6 +269,114 @@ namespace shadcnui.GUIComponents
         Default,
         Large
     }
+
+    /// <summary>
+    /// Variants for the Calendar component.
+    /// </summary>
+    public enum CalendarVariant
+    {
+        Default
+    }
+
+    /// <summary>
+    /// Sizes for the Calendar component.
+    /// </summary>
+    public enum CalendarSize
+    {
+        Default,
+        Small,
+        Large
+    }
+
+    /// <summary>
+    /// Variants for the Dialog component.
+    /// </summary>
+    public enum DialogVariant
+    {
+        Default
+    }
+
+    /// <summary>
+    /// Sizes for the Dialog component.
+    /// </summary>
+    public enum DialogSize
+    {
+        Default,
+        Small,
+        Large
+    }
+
+    /// <summary>
+    /// Variants for the DropdownMenu component.
+    /// </summary>
+    public enum DropdownMenuVariant
+    {
+        Default
+    }
+
+    /// <summary>
+    /// Sizes for the DropdownMenu component.
+    /// </summary>
+    public enum DropdownMenuSize
+    {
+        Default,
+        Small,
+        Large
+    }
+
+    /// <summary>
+    /// Variants for the Popover component.
+    /// </summary>
+    public enum PopoverVariant
+    {
+        Default
+    }
+
+    /// <summary>
+    /// Sizes for the Popover component.
+    /// </summary>
+    public enum PopoverSize
+    {
+        Default,
+        Small,
+        Large
+    }
+
+    /// <summary>
+    /// Variants for the ScrollArea component.
+    /// </summary>
+    public enum ScrollAreaVariant
+    {
+        Default
+    }
+
+    /// <summary>
+    /// Sizes for the ScrollArea component.
+    /// </summary>
+    public enum ScrollAreaSize
+    {
+        Default,
+        Small,
+        Large
+    }
+
+    /// <summary>
+    /// Variants for the Select component.
+    /// </summary>
+    public enum SelectVariant
+    {
+        Default
+    }
+
+    /// <summary>
+    /// Sizes for the Select component.
+    /// </summary>
+    public enum SelectSize
+    {
+        Default,
+        Small,
+        Large
+    }
     #endregion
 
     /// <summary>
@@ -415,6 +523,44 @@ namespace shadcnui.GUIComponents
         public GUIStyle labelSmallScaledStyle;
         public GUIStyle labelMediumScaledStyle;
         public GUIStyle labelLargeScaledStyle;
+
+        // Calendar Styles
+        public GUIStyle calendarStyle;
+        public GUIStyle calendarHeaderStyle;
+        public GUIStyle calendarTitleStyle;
+        public GUIStyle calendarWeekdayStyle;
+        public GUIStyle calendarDayStyle;
+        public GUIStyle calendarDaySelectedStyle;
+        public GUIStyle calendarDayOutsideMonthStyle;
+        public GUIStyle calendarDayTodayStyle;
+        public GUIStyle calendarSmallStyle;
+        public GUIStyle calendarLargeStyle;
+
+        // DropdownMenu Styles
+        public GUIStyle dropdownMenuContentStyle;
+        public GUIStyle dropdownMenuItemStyle;
+        public GUIStyle dropdownMenuSeparatorStyle;
+        public GUIStyle dropdownMenuSmallStyle;
+        public GUIStyle dropdownMenuLargeStyle;
+
+        // Popover Styles
+        public GUIStyle popoverContentStyle;
+        public GUIStyle popoverSmallStyle;
+        public GUIStyle popoverLargeStyle;
+
+        // ScrollArea Styles
+        public GUIStyle scrollAreaStyle;
+        public GUIStyle scrollAreaThumbStyle;
+        public GUIStyle scrollAreaTrackStyle;
+        public GUIStyle scrollAreaSmallStyle;
+        public GUIStyle scrollAreaLargeStyle;
+
+        // Select Styles
+        public GUIStyle selectTriggerStyle;
+        public GUIStyle selectContentStyle;
+        public GUIStyle selectItemStyle;
+        public GUIStyle selectSmallStyle;
+        public GUIStyle selectLargeStyle;
         #endregion
 
         #region Texture Fields
@@ -444,6 +590,26 @@ namespace shadcnui.GUIComponents
         private Texture2D tableTexture;
         private Texture2D tableHeaderTexture;
         private Texture2D tableCellTexture;
+
+        // Calendar Textures
+        private Texture2D calendarBackgroundTexture;
+        private Texture2D calendarHeaderTexture;
+        private Texture2D calendarDayTexture;
+        private Texture2D calendarDaySelectedTexture;
+
+        // DropdownMenu Textures
+        private Texture2D dropdownMenuContentTexture;
+
+        // Popover Textures
+        private Texture2D popoverContentTexture;
+
+        // ScrollArea Textures
+        private Texture2D scrollAreaThumbTexture;
+        private Texture2D scrollAreaTrackTexture;
+
+        // Select Textures
+        private Texture2D selectTriggerTexture;
+        private Texture2D selectContentTexture;
         #endregion
 
         public GUIStyleManager(GUIHelper helper)
@@ -475,6 +641,11 @@ namespace shadcnui.GUIComponents
             SetupAvatarStyles();
             SetupSkeletonStyles();
             SetupTableStyles();
+            SetupCalendarStyles();
+            SetupDropdownMenuStyles();
+            SetupPopoverStyles();
+            SetupScrollAreaStyles();
+            SetupSelectStyles();
         }
         #endregion
 
@@ -1593,6 +1764,191 @@ namespace shadcnui.GUIComponents
             tableHoverStyle = new GUIStyle(tableStyle);
             tableHoverStyle.hover.background = CreateSolidTexture(new Color(0.1f, 0.1f, 0.15f));
         }
+
+        private void SetupCalendarStyles()
+        {
+            float scaledFontSize = guiHelper.fontSize * guiHelper.uiScale;
+            int borderRadius = Mathf.RoundToInt(guiHelper.cornerRadius * guiHelper.uiScale);
+
+            calendarBackgroundTexture = new Texture2D(1, 1);
+            Color calendarBgColor = guiHelper.customColorsEnabled ?
+                new Color(guiHelper.primaryColor.r, guiHelper.primaryColor.g, guiHelper.primaryColor.b, guiHelper.backgroundAlpha) :
+                new Color(0.15f, 0.15f, 0.25f, guiHelper.backgroundAlpha);
+            calendarBackgroundTexture.SetPixel(0, 0, calendarBgColor);
+            calendarBackgroundTexture.Apply();
+
+            calendarHeaderTexture = new Texture2D(1, 1);
+            Color calendarHeaderBgColor = guiHelper.customColorsEnabled ?
+                new Color(guiHelper.primaryColor.r * 0.8f, guiHelper.primaryColor.g * 0.8f, guiHelper.primaryColor.b * 0.8f, guiHelper.backgroundAlpha) :
+                new Color(0.2f, 0.2f, 0.3f, guiHelper.backgroundAlpha);
+            calendarHeaderTexture.SetPixel(0, 0, calendarHeaderBgColor);
+            calendarHeaderTexture.Apply();
+
+            calendarDayTexture = new Texture2D(1, 1);
+            Color calendarDayBgColor = new Color(0, 0, 0, 0);
+            calendarDayTexture.SetPixel(0, 0, calendarDayBgColor);
+            calendarDayTexture.Apply();
+
+            calendarDaySelectedTexture = new Texture2D(1, 1);
+            Color calendarDaySelectedBgColor = guiHelper.customColorsEnabled ? guiHelper.accentColor : new Color(0.25f, 0.5f, 1f);
+            calendarDaySelectedTexture.SetPixel(0, 0, calendarDaySelectedBgColor);
+            calendarDaySelectedTexture.Apply();
+
+            calendarStyle = new GUIStyle(GUI.skin.box);
+            calendarStyle.normal.background = calendarBackgroundTexture;
+            calendarStyle.border = new RectOffset(borderRadius, borderRadius, borderRadius, borderRadius);
+            calendarStyle.padding = new RectOffset(10, 10, 10, 10);
+
+            calendarHeaderStyle = new GUIStyle(GUI.skin.box);
+            calendarHeaderStyle.normal.background = calendarHeaderTexture;
+            calendarHeaderStyle.padding = new RectOffset(5, 5, 5, 5);
+            calendarHeaderStyle.alignment = TextAnchor.MiddleCenter;
+
+            calendarTitleStyle = new GUIStyle(GUI.skin.label);
+            calendarTitleStyle.fontSize = Mathf.RoundToInt(scaledFontSize * 1.2f);
+            calendarTitleStyle.fontStyle = FontStyle.Bold;
+            calendarTitleStyle.normal.textColor = Color.white;
+            calendarTitleStyle.alignment = TextAnchor.MiddleCenter;
+
+            calendarWeekdayStyle = new GUIStyle(GUI.skin.label);
+            calendarWeekdayStyle.fontSize = Mathf.RoundToInt(scaledFontSize * 0.9f);
+            calendarWeekdayStyle.fontStyle = FontStyle.Normal;
+            calendarWeekdayStyle.normal.textColor = new Color(0.8f, 0.8f, 0.8f);
+            calendarWeekdayStyle.alignment = TextAnchor.MiddleCenter;
+
+            calendarDayStyle = new GUIStyle(GUI.skin.button);
+            calendarDayStyle.fontSize = Mathf.RoundToInt(scaledFontSize);
+            calendarDayStyle.fontStyle = FontStyle.Normal;
+            calendarDayStyle.alignment = TextAnchor.MiddleCenter;
+            calendarDayStyle.normal.background = calendarDayTexture;
+            calendarDayStyle.normal.textColor = Color.white;
+            calendarDayStyle.hover.background = CreateSolidTexture(new Color(0.25f, 0.25f, 0.35f));
+            calendarDayStyle.active.background = CreateSolidTexture(new Color(0.2f, 0.2f, 0.3f));
+
+            calendarDaySelectedStyle = new GUIStyle(calendarDayStyle);
+            calendarDaySelectedStyle.normal.background = calendarDaySelectedTexture;
+            calendarDaySelectedStyle.normal.textColor = Color.white;
+
+            calendarDayOutsideMonthStyle = new GUIStyle(calendarDayStyle);
+            calendarDayOutsideMonthStyle.normal.textColor = new Color(0.5f, 0.5f, 0.5f);
+
+            calendarDayTodayStyle = new GUIStyle(calendarDayStyle);
+            calendarDayTodayStyle.fontStyle = FontStyle.Bold;
+            calendarDayTodayStyle.normal.textColor = guiHelper.customColorsEnabled ? guiHelper.accentColor : new Color(0.25f, 0.5f, 1f);
+        }
+
+        private void SetupDropdownMenuStyles()
+        {
+            float scaledFontSize = guiHelper.fontSize * guiHelper.uiScale;
+            int borderRadius = Mathf.RoundToInt(guiHelper.cornerRadius * guiHelper.uiScale);
+
+            dropdownMenuContentTexture = new Texture2D(1, 1);
+            Color dropdownMenuContentBgColor = guiHelper.customColorsEnabled ?
+                new Color(guiHelper.primaryColor.r, guiHelper.primaryColor.g, guiHelper.primaryColor.b, 1f) :
+                new Color(0.1f, 0.1f, 0.15f, 1f);
+            dropdownMenuContentTexture.SetPixel(0, 0, dropdownMenuContentBgColor);
+            dropdownMenuContentTexture.Apply();
+
+            dropdownMenuContentStyle = new GUIStyle(GUI.skin.box);
+            dropdownMenuContentStyle.normal.background = dropdownMenuContentTexture;
+            dropdownMenuContentStyle.border = new RectOffset(borderRadius, borderRadius, borderRadius, borderRadius);
+            dropdownMenuContentStyle.padding = new RectOffset(5, 5, 5, 5);
+
+            dropdownMenuItemStyle = new GUIStyle(GUI.skin.button);
+            dropdownMenuItemStyle.fontSize = Mathf.RoundToInt(scaledFontSize);
+            dropdownMenuItemStyle.fontStyle = FontStyle.Normal;
+            dropdownMenuItemStyle.alignment = TextAnchor.MiddleLeft;
+            dropdownMenuItemStyle.normal.background = transparentTexture;
+            dropdownMenuItemStyle.normal.textColor = Color.white;
+            dropdownMenuItemStyle.hover.background = CreateSolidTexture(new Color(0.25f, 0.25f, 0.35f));
+            dropdownMenuItemStyle.active.background = CreateSolidTexture(new Color(0.2f, 0.2f, 0.3f));
+            dropdownMenuItemStyle.padding = new RectOffset(10, 10, 5, 5);
+
+            dropdownMenuSeparatorStyle = new GUIStyle();
+            dropdownMenuSeparatorStyle.normal.background = separatorTexture;
+            dropdownMenuSeparatorStyle.fixedHeight = 1;
+            dropdownMenuSeparatorStyle.margin = new RectOffset(5, 5, 5, 5);
+        }
+
+        private void SetupPopoverStyles()
+        {
+            float scaledFontSize = guiHelper.fontSize * guiHelper.uiScale;
+            int borderRadius = Mathf.RoundToInt(guiHelper.cornerRadius * guiHelper.uiScale);
+
+            popoverContentTexture = new Texture2D(1, 1);
+            Color popoverContentBgColor = guiHelper.customColorsEnabled ?
+                new Color(guiHelper.primaryColor.r, guiHelper.primaryColor.g, guiHelper.primaryColor.b, 1f) :
+                new Color(0.1f, 0.1f, 0.15f, 1f);
+            popoverContentTexture.SetPixel(0, 0, popoverContentBgColor);
+            popoverContentTexture.Apply();
+
+            popoverContentStyle = new GUIStyle(GUI.skin.box);
+            popoverContentStyle.normal.background = popoverContentTexture;
+            popoverContentStyle.border = new RectOffset(borderRadius, borderRadius, borderRadius, borderRadius);
+            popoverContentStyle.padding = new RectOffset(10, 10, 10, 10);
+        }
+
+        private void SetupScrollAreaStyles()
+        {
+            scrollAreaThumbTexture = new Texture2D(1, 1);
+            scrollAreaThumbTexture.SetPixel(0, 0, new Color(0.5f, 0.5f, 0.5f, 0.5f));
+            scrollAreaThumbTexture.Apply();
+
+            scrollAreaTrackTexture = new Texture2D(1, 1);
+            scrollAreaTrackTexture.SetPixel(0, 0, new Color(0.2f, 0.2f, 0.2f, 0.5f));
+            scrollAreaTrackTexture.Apply();
+
+            scrollAreaStyle = new GUIStyle(GUI.skin.scrollView);
+
+            scrollAreaThumbStyle = new GUIStyle(GUI.skin.verticalScrollbarThumb);
+            scrollAreaThumbStyle.normal.background = scrollAreaThumbTexture;
+
+            scrollAreaTrackStyle = new GUIStyle(GUI.skin.verticalScrollbar);
+            scrollAreaTrackStyle.normal.background = scrollAreaTrackTexture;
+        }
+
+        private void SetupSelectStyles()
+        {
+            float scaledFontSize = guiHelper.fontSize * guiHelper.uiScale;
+            int borderRadius = Mathf.RoundToInt(guiHelper.cornerRadius * guiHelper.uiScale);
+
+            selectTriggerTexture = new Texture2D(1, 1);
+            Color selectTriggerBgColor = guiHelper.customColorsEnabled ?
+                new Color(guiHelper.primaryColor.r, guiHelper.primaryColor.g, guiHelper.primaryColor.b, 1f) :
+                new Color(0.1f, 0.1f, 0.15f, 1f);
+            selectTriggerTexture.SetPixel(0, 0, selectTriggerBgColor);
+            selectTriggerTexture.Apply();
+
+            selectContentTexture = new Texture2D(1, 1);
+            Color selectContentBgColor = guiHelper.customColorsEnabled ?
+                new Color(guiHelper.primaryColor.r, guiHelper.primaryColor.g, guiHelper.primaryColor.b, 1f) :
+                new Color(0.1f, 0.1f, 0.15f, 1f);
+            selectContentTexture.SetPixel(0, 0, selectContentBgColor);
+            selectContentTexture.Apply();
+
+            selectTriggerStyle = new GUIStyle(GUI.skin.button);
+            selectTriggerStyle.normal.background = selectTriggerTexture;
+            selectTriggerStyle.border = new RectOffset(borderRadius, borderRadius, borderRadius, borderRadius);
+            selectTriggerStyle.padding = new RectOffset(10, 10, 5, 5);
+            selectTriggerStyle.alignment = TextAnchor.MiddleLeft;
+            selectTriggerStyle.normal.textColor = Color.white;
+            selectTriggerStyle.fontSize = Mathf.RoundToInt(scaledFontSize);
+
+            selectContentStyle = new GUIStyle(GUI.skin.box);
+            selectContentStyle.normal.background = selectContentTexture;
+            selectContentStyle.border = new RectOffset(borderRadius, borderRadius, borderRadius, borderRadius);
+            selectContentStyle.padding = new RectOffset(5, 5, 5, 5);
+
+            selectItemStyle = new GUIStyle(GUI.skin.button);
+            selectItemStyle.fontSize = Mathf.RoundToInt(scaledFontSize);
+            selectItemStyle.fontStyle = FontStyle.Normal;
+            selectItemStyle.alignment = TextAnchor.MiddleLeft;
+            selectItemStyle.normal.background = transparentTexture;
+            selectItemStyle.normal.textColor = Color.white;
+            selectItemStyle.hover.background = CreateSolidTexture(new Color(0.25f, 0.25f, 0.35f));
+            selectItemStyle.active.background = CreateSolidTexture(new Color(0.2f, 0.2f, 0.3f));
+            selectItemStyle.padding = new RectOffset(10, 10, 5, 5);
+        }
         #endregion
 
         #region Style Getters
@@ -2176,6 +2532,49 @@ namespace shadcnui.GUIComponents
         {
             return tableCellStyle ?? GUI.skin.label;
         }
+
+        /// <summary>
+        /// Gets the calendar style for the given variant and size.
+        /// </summary>
+        public GUIStyle GetCalendarStyle(CalendarVariant variant, CalendarSize size)
+        {
+            return calendarStyle;
+        }
+
+        /// <summary>
+        /// Gets the dropdown menu style for the given variant and size.
+        /// </summary>
+        public GUIStyle GetDropdownMenuStyle(DropdownMenuVariant variant, DropdownMenuSize size)
+        {
+            return dropdownMenuContentStyle;
+        }
+
+        /// <summary>
+        /// Gets the popover style for the given variant and size.
+        /// </summary>
+        public GUIStyle GetPopoverStyle(PopoverVariant variant, PopoverSize size)
+        {
+            return popoverContentStyle;
+        }
+
+        /// <summary>
+        /// Gets the scroll area style for the given variant and size.
+        /// </summary>
+        public GUIStyle GetScrollAreaStyle(ScrollAreaVariant variant, ScrollAreaSize size)
+        {
+            return scrollAreaStyle;
+        }
+
+        /// <summary>
+        /// Gets the select style for the given variant and size.
+        /// </summary>
+        public GUIStyle GetSelectStyle(SelectVariant variant, SelectSize size)
+        {
+            return selectContentStyle;
+        }
+
+        public GUIStyle GetSelectTriggerStyle() => selectTriggerStyle;
+        public GUIStyle GetSelectItemStyle() => selectItemStyle;
         #endregion
 
         #region Cleanup

--- a/shadcnui/GUIComponents/GUISwitchComponents.cs
+++ b/shadcnui/GUIComponents/GUISwitchComponents.cs
@@ -8,10 +8,12 @@ namespace shadcnui.GUIComponents
     public class GUISwitchComponents
     {
         private GUIHelper guiHelper;
+        private GUILayoutComponents layoutComponents;
 
         public GUISwitchComponents(GUIHelper helper)
         {
             guiHelper = helper;
+            layoutComponents = new GUILayoutComponents(helper);
         }
 
         public bool Switch(string text, bool value, SwitchVariant variant = SwitchVariant.Default,
@@ -76,14 +78,22 @@ namespace shadcnui.GUIComponents
             return newValue && !disabled;
         }
 
-        public bool SwitchWithLabel(string label, bool value, SwitchVariant variant = SwitchVariant.Default,
+        public bool SwitchWithLabel(string label, ref bool value, SwitchVariant variant = SwitchVariant.Default,
             SwitchSize size = SwitchSize.Default, Action<bool> onToggle = null, bool disabled = false)
         {
-            GUILayout.BeginHorizontal();
-            
+            layoutComponents.BeginHorizontalGroup();
+
+            bool newValue = Switch("", value, variant, size, onToggle, disabled, GUILayout.Width(40 * guiHelper.uiScale));
+
+            if (newValue != value)
+            {
+                value = newValue;
+                onToggle?.Invoke(newValue);
+            }
+
             var styleManager = guiHelper.GetStyleManager();
             GUIStyle labelStyle = styleManager?.GetLabelStyle(LabelVariant.Default) ?? GUI.skin.label;
-            
+
             Color originalColor = GUI.color;
             if (disabled)
             {
@@ -97,23 +107,18 @@ namespace shadcnui.GUIComponents
 #endif
 
             GUI.color = originalColor;
-            
-            GUILayout.FlexibleSpace();
-            
-            bool newValue = Switch("", value, variant, size, onToggle, disabled, GUILayout.Width(50 * guiHelper.uiScale));
-            
-            GUILayout.EndHorizontal();
+            layoutComponents.EndHorizontalGroup();
 
             return newValue;
         }
 
-        public bool SwitchWithDescription(string label, string description, bool value, 
+        public bool SwitchWithDescription(string label, string description, ref bool value, 
             SwitchVariant variant = SwitchVariant.Default, SwitchSize size = SwitchSize.Default,
             Action<bool> onToggle = null, bool disabled = false)
         {
-            GUILayout.BeginVertical();
+            layoutComponents.BeginVerticalGroup();
             
-            bool newValue = SwitchWithLabel(label, value, variant, size, onToggle, disabled);
+            bool newValue = SwitchWithLabel(label, ref value, variant, size, onToggle, disabled);
             
             if (!string.IsNullOrEmpty(description))
             {
@@ -126,7 +131,7 @@ namespace shadcnui.GUIComponents
                     GUI.color = new Color(originalColor.r, originalColor.g, originalColor.b, 0.7f);
                 }
 
-                GUILayout.Space(2 * guiHelper.uiScale);
+                layoutComponents.AddSpace(2);
 #if IL2CPP
                 GUILayout.Label(description, descStyle, (Il2CppReferenceArray<GUILayoutOption>)null);
 #else
@@ -136,7 +141,7 @@ namespace shadcnui.GUIComponents
                 GUI.color = originalColor;
             }
             
-            GUILayout.EndVertical();
+            layoutComponents.EndVerticalGroup();
 
             return newValue;
         }
@@ -216,20 +221,20 @@ namespace shadcnui.GUIComponents
             return newValue;
         }
 
-        public bool ValidatedSwitch(string text, bool value, bool isValid, string validationMessage,
+        public bool ValidatedSwitch(string text, ref bool value, bool isValid, string validationMessage,
             SwitchVariant variant = SwitchVariant.Default, SwitchSize size = SwitchSize.Default,
             Action<bool> onToggle = null, bool disabled = false)
         {
-            GUILayout.BeginVertical();
+            layoutComponents.BeginVerticalGroup();
             
-            bool newValue = SwitchWithLabel(text, value, variant, size, onToggle, disabled);
+            bool newValue = SwitchWithLabel(text, ref value, variant, size, onToggle, disabled);
             
             if (!isValid && !string.IsNullOrEmpty(validationMessage))
             {
                 var styleManager = guiHelper.GetStyleManager();
                 GUIStyle errorStyle = styleManager?.GetLabelStyle(LabelVariant.Destructive) ?? GUI.skin.label;
                 
-                GUILayout.Space(2 * guiHelper.uiScale);
+                layoutComponents.AddSpace(2);
 #if IL2CPP
                 GUILayout.Label(validationMessage, errorStyle, (Il2CppReferenceArray<GUILayoutOption>)null);
 #else
@@ -237,21 +242,21 @@ namespace shadcnui.GUIComponents
 #endif
             }
             
-            GUILayout.EndVertical();
+            layoutComponents.EndVerticalGroup();
 
             return newValue;
         }
 
-        public bool SwitchWithTooltip(string text, bool value, string tooltip, SwitchVariant variant = SwitchVariant.Default,
+        public bool SwitchWithTooltip(string text, ref bool value, string tooltip, SwitchVariant variant = SwitchVariant.Default,
             SwitchSize size = SwitchSize.Default, Action<bool> onToggle = null, bool disabled = false)
         {
-            GUILayout.BeginHorizontal();
+            layoutComponents.BeginHorizontalGroup();
             
-            bool newValue = SwitchWithLabel(text, value, variant, size, onToggle, disabled);
+            bool newValue = SwitchWithLabel(text, ref value, variant, size, onToggle, disabled);
             
             if (!string.IsNullOrEmpty(tooltip))
             {
-                GUILayout.Space(4 * guiHelper.uiScale);
+                layoutComponents.AddSpace(4);
                 
                 var styleManager = guiHelper.GetStyleManager();
                 GUIStyle tooltipStyle = styleManager?.GetLabelStyle(LabelVariant.Muted) ?? GUI.skin.label;
@@ -268,7 +273,7 @@ namespace shadcnui.GUIComponents
                 GUI.color = originalColor;
             }
             
-            GUILayout.EndHorizontal();
+            layoutComponents.EndHorizontalGroup();
 
             return newValue;
         }
@@ -288,17 +293,17 @@ namespace shadcnui.GUIComponents
 
             if (horizontal)
             {
-                GUILayout.BeginHorizontal();
+                layoutComponents.BeginHorizontalGroup();
             }
             else
             {
-                GUILayout.BeginVertical();
+                layoutComponents.BeginVerticalGroup();
             }
 
             for (int i = 0; i < labels.Length; i++)
             {
                 int index = i;
-                bool newValue = SwitchWithLabel(labels[i], values[i], variant, size, 
+                bool newValue = SwitchWithLabel(labels[i], ref newValues[i], variant, size, 
                     (val) => {
                         newValues[index] = val;
                         onToggleChange?.Invoke(index, val);
@@ -306,14 +311,14 @@ namespace shadcnui.GUIComponents
 
                 if (i < labels.Length - 1)
                 {
-                    GUILayout.Space(spacing * guiHelper.uiScale);
+                    layoutComponents.AddSpace(spacing);
                 }
             }
 
             if (horizontal)
-                GUILayout.EndHorizontal();
+                layoutComponents.EndHorizontalGroup();
             else
-                GUILayout.EndVertical();
+                layoutComponents.EndVerticalGroup();
 
             return newValues;
         }
@@ -321,13 +326,13 @@ namespace shadcnui.GUIComponents
         public bool SwitchWithLoading(string text, bool value, bool isLoading, SwitchVariant variant = SwitchVariant.Default,
             SwitchSize size = SwitchSize.Default, Action<bool> onToggle = null, bool disabled = false)
         {
-            GUILayout.BeginHorizontal();
+            layoutComponents.BeginHorizontalGroup();
             
-            bool newValue = SwitchWithLabel(text, value, variant, size, onToggle, disabled || isLoading);
+            bool newValue = SwitchWithLabel(text, ref value, variant, size, onToggle, disabled || isLoading);
             
             if (isLoading)
             {
-                GUILayout.Space(4 * guiHelper.uiScale);
+                layoutComponents.AddSpace(4);
                 
                 float time = Time.time * 2f;
                 float alpha = (Mathf.Sin(time) + 1f) * 0.5f;
@@ -347,7 +352,7 @@ namespace shadcnui.GUIComponents
                 GUI.color = originalColor;
             }
             
-            GUILayout.EndHorizontal();
+            layoutComponents.EndHorizontalGroup();
 
             return newValue;
         }

--- a/shadcnui/GUIComponents/GUITableComponents.cs
+++ b/shadcnui/GUIComponents/GUITableComponents.cs
@@ -8,10 +8,12 @@ namespace shadcnui.GUIComponents
     public class GUITableComponents
     {
         private GUIHelper guiHelper;
+        private GUILayoutComponents layoutComponents;
 
         public GUITableComponents(GUIHelper helper)
         {
             guiHelper = helper;
+            layoutComponents = new GUILayoutComponents(helper);
         }
 
         public void Table(string[] headers, string[,] data, TableVariant variant = TableVariant.Default,
@@ -30,9 +32,9 @@ namespace shadcnui.GUIComponents
             GUIStyle headerStyle = styleManager.GetTableHeaderStyle(variant, size);
             GUIStyle cellStyle = styleManager.GetTableCellStyle(variant, size);
 
-            GUILayout.BeginVertical(tableStyle, options);
+            layoutComponents.BeginVerticalGroup(tableStyle, options);
 
-            GUILayout.BeginHorizontal();
+            layoutComponents.BeginHorizontalGroup();
             for (int i = 0; i < headers.Length; i++)
             {
 #if IL2CPP
@@ -41,14 +43,14 @@ namespace shadcnui.GUIComponents
                 GUILayout.Label(headers[i], headerStyle);
 #endif
             }
-            GUILayout.EndHorizontal();
+            layoutComponents.EndHorizontalGroup();
 
             int rowCount = data.GetLength(0);
             int colCount = data.GetLength(1);
 
             for (int row = 0; row < rowCount; row++)
             {
-                GUILayout.BeginHorizontal();
+                layoutComponents.BeginHorizontalGroup();
 
                 for (int col = 0; col < colCount; col++)
                 {
@@ -60,10 +62,10 @@ namespace shadcnui.GUIComponents
 #endif
                 }
 
-                GUILayout.EndHorizontal();
+                layoutComponents.EndHorizontalGroup();
             }
 
-            GUILayout.EndVertical();
+            layoutComponents.EndVerticalGroup();
         }
 
         public void Table(Rect rect, string[] headers, string[,] data, TableVariant variant = TableVariant.Default, 
@@ -95,11 +97,11 @@ namespace shadcnui.GUIComponents
         }
 
         public void SortableTable(string[] headers, string[,] data, ref int[] sortColumns, ref bool[] sortAscending,
-            TableVariant variant = TableVariant.Default, TableSize size = TableSize.Default, 
+            TableVariant variant = TableVariant.Default, TableSize size = TableSize.Default,
             Action<int, bool> onSort = null, params GUILayoutOption[] options)
         {
             if (headers == null || data == null) return;
-            
+
             var styleManager = guiHelper.GetStyleManager();
             if (styleManager == null)
             {
@@ -111,14 +113,14 @@ namespace shadcnui.GUIComponents
             GUIStyle headerStyle = styleManager.GetTableHeaderStyle(variant, size);
             GUIStyle cellStyle = styleManager.GetTableCellStyle(variant, size);
 
-            GUILayout.BeginVertical(tableStyle, options);
-            
-            GUILayout.BeginHorizontal();
+            layoutComponents.BeginVerticalGroup(tableStyle, options);
+
+            layoutComponents.BeginHorizontalGroup();
             for (int i = 0; i < headers.Length; i++)
             {
                 int columnIndex = i;
                 string headerText = headers[i];
-                
+
                 if (sortColumns != null && sortAscending != null && i < sortColumns.Length)
                 {
                     if (sortColumns[i] == i)
@@ -126,7 +128,7 @@ namespace shadcnui.GUIComponents
                         headerText += sortAscending[i] ? " ↑" : " ↓";
                     }
                 }
-                
+
                 if (GUILayout.Button(headerText, headerStyle))
                 {
                     if (onSort != null)
@@ -143,15 +145,15 @@ namespace shadcnui.GUIComponents
                     }
                 }
             }
-            GUILayout.EndHorizontal();
-            
+            layoutComponents.EndHorizontalGroup();
+
             int rowCount = data.GetLength(0);
             int colCount = data.GetLength(1);
-            
+
             for (int row = 0; row < rowCount; row++)
             {
-                GUILayout.BeginHorizontal();
-                
+                layoutComponents.BeginHorizontalGroup();
+
                 for (int col = 0; col < colCount; col++)
                 {
                     string cellValue = data[row, col] ?? "";
@@ -161,19 +163,19 @@ namespace shadcnui.GUIComponents
                     GUILayout.Label(cellValue, cellStyle);
 #endif
                 }
-                
-                GUILayout.EndHorizontal();
+
+                layoutComponents.EndHorizontalGroup();
             }
-            
-            GUILayout.EndVertical();
+
+            layoutComponents.EndVerticalGroup();
         }
 
         public void SelectableTable(string[] headers, string[,] data, ref bool[] selectedRows,
-            TableVariant variant = TableVariant.Default, TableSize size = TableSize.Default, 
+            TableVariant variant = TableVariant.Default, TableSize size = TableSize.Default,
             Action<int, bool> onSelectionChange = null, params GUILayoutOption[] options)
         {
             if (headers == null || data == null) return;
-            
+
             var styleManager = guiHelper.GetStyleManager();
             if (styleManager == null)
             {
@@ -185,9 +187,9 @@ namespace shadcnui.GUIComponents
             GUIStyle headerStyle = styleManager.GetTableHeaderStyle(variant, size);
             GUIStyle cellStyle = styleManager.GetTableCellStyle(variant, size);
 
-            GUILayout.BeginVertical(tableStyle, options);
-            
-            GUILayout.BeginHorizontal();
+            layoutComponents.BeginVerticalGroup(tableStyle, options);
+
+            layoutComponents.BeginHorizontalGroup();
             GUILayout.Label("", GUILayout.Width(20 * guiHelper.uiScale));
             for (int i = 0; i < headers.Length; i++)
             {
@@ -197,27 +199,27 @@ namespace shadcnui.GUIComponents
                 GUILayout.Label(headers[i], headerStyle);
 #endif
             }
-            GUILayout.EndHorizontal();
-            
+            layoutComponents.EndHorizontalGroup();
+
             int rowCount = data.GetLength(0);
             int colCount = data.GetLength(1);
-            
+
             if (selectedRows == null || selectedRows.Length != rowCount)
             {
                 selectedRows = new bool[rowCount];
             }
-            
+
             for (int row = 0; row < rowCount; row++)
             {
-                GUILayout.BeginHorizontal();
-                
+                layoutComponents.BeginHorizontalGroup();
+
                 bool newSelected = GUILayout.Toggle(selectedRows[row], "", GUILayout.Width(20 * guiHelper.uiScale));
                 if (newSelected != selectedRows[row])
                 {
                     selectedRows[row] = newSelected;
                     onSelectionChange?.Invoke(row, newSelected);
                 }
-                
+
                 for (int col = 0; col < colCount; col++)
                 {
                     string cellValue = data[row, col] ?? "";
@@ -227,11 +229,11 @@ namespace shadcnui.GUIComponents
                     GUILayout.Label(cellValue, cellStyle);
 #endif
                 }
-                
-                GUILayout.EndHorizontal();
+
+                layoutComponents.EndHorizontalGroup();
             }
-            
-            GUILayout.EndVertical();
+
+            layoutComponents.EndVerticalGroup();
         }
 
         public void CustomTable(string[] headers, object[,] data, Action<object, int, int> cellRenderer,
@@ -250,9 +252,9 @@ namespace shadcnui.GUIComponents
             GUIStyle tableStyle = styleManager.GetTableStyle(variant, size);
             GUIStyle headerStyle = styleManager.GetTableHeaderStyle(variant, size);
 
-            GUILayout.BeginVertical(tableStyle, options);
+            layoutComponents.BeginVerticalGroup(tableStyle, options);
             
-            GUILayout.BeginHorizontal();
+            layoutComponents.BeginHorizontalGroup();
             for (int i = 0; i < headers.Length; i++)
             {
 #if IL2CPP
@@ -261,14 +263,14 @@ namespace shadcnui.GUIComponents
                 GUILayout.Label(headers[i], headerStyle);
 #endif
             }
-            GUILayout.EndHorizontal();
+            layoutComponents.EndHorizontalGroup();
             
             int rowCount = data.GetLength(0);
             int colCount = data.GetLength(1);
             
             for (int row = 0; row < rowCount; row++)
             {
-                GUILayout.BeginHorizontal();
+                layoutComponents.BeginHorizontalGroup();
                 
                 for (int col = 0; col < colCount; col++)
                 {
@@ -276,10 +278,10 @@ namespace shadcnui.GUIComponents
                     cellRenderer.Invoke(cellValue, row, col);
                 }
                 
-                GUILayout.EndHorizontal();
+                layoutComponents.EndHorizontalGroup();
             }
             
-            GUILayout.EndVertical();
+            layoutComponents.EndVerticalGroup();
         }
 
         public void PaginatedTable(string[] headers, string[,] data, ref int currentPage, int pageSize,
@@ -310,8 +312,8 @@ namespace shadcnui.GUIComponents
             
             Table(headers, pageData, variant, size, options);
             
-            GUILayout.Space(8 * guiHelper.uiScale);
-            GUILayout.BeginHorizontal();
+            layoutComponents.AddSpace(8);
+            layoutComponents.BeginHorizontalGroup();
             
             bool prevClicked = GUILayout.Button("← Previous", GUILayout.Width(80 * guiHelper.uiScale));
             if (prevClicked && currentPage > 0)
@@ -336,7 +338,7 @@ namespace shadcnui.GUIComponents
                 onPageChange?.Invoke(currentPage);
             }
             
-            GUILayout.EndHorizontal();
+            layoutComponents.EndHorizontalGroup();
         }
 
         public void SearchableTable(string[] headers, string[,] data, ref string searchQuery, ref string[,] filteredData,
@@ -345,7 +347,7 @@ namespace shadcnui.GUIComponents
         {
             if (headers == null || data == null) return;
             
-            GUILayout.BeginHorizontal();
+            layoutComponents.BeginHorizontalGroup();
             GUILayout.Label("Search:", GUILayout.Width(60 * guiHelper.uiScale));
             string newSearchQuery = GUILayout.TextField(searchQuery ?? "", GUILayout.Width(200 * guiHelper.uiScale));
             if (newSearchQuery != searchQuery)
@@ -355,9 +357,9 @@ namespace shadcnui.GUIComponents
                 
                 filteredData = FilterTableData(data, searchQuery);
             }
-            GUILayout.EndHorizontal();
+            layoutComponents.EndHorizontalGroup();
             
-            GUILayout.Space(8 * guiHelper.uiScale);
+            layoutComponents.AddSpace(8);
             
             string[,] displayData = filteredData ?? data;
             Table(headers, displayData, variant, size, options);
@@ -390,9 +392,9 @@ namespace shadcnui.GUIComponents
             GUIStyle headerStyle = styleManager.GetTableHeaderStyle(variant, size);
             GUIStyle cellStyle = styleManager.GetTableCellStyle(variant, size);
 
-            GUILayout.BeginVertical(tableStyle, options);
+            layoutComponents.BeginVerticalGroup(tableStyle, options);
             
-            GUILayout.BeginHorizontal();
+            layoutComponents.BeginHorizontalGroup();
             for (int i = 0; i < headers.Length; i++)
             {
                 int columnIndex = i;
@@ -405,14 +407,14 @@ namespace shadcnui.GUIComponents
                 GUILayout.Label(headers[i], headerStyle, GUILayout.Width(width));
 #endif
             }
-            GUILayout.EndHorizontal();
+            layoutComponents.EndHorizontalGroup();
             
             int rowCount = data.GetLength(0);
             int colCount = data.GetLength(1);
             
             for (int row = 0; row < rowCount; row++)
             {
-                GUILayout.BeginHorizontal();
+                layoutComponents.BeginHorizontalGroup();
                 
                 for (int col = 0; col < colCount; col++)
                 {
@@ -427,29 +429,29 @@ namespace shadcnui.GUIComponents
 #endif
                 }
                 
-                GUILayout.EndHorizontal();
+                layoutComponents.EndHorizontalGroup();
             }
             
-            GUILayout.EndVertical();
+            layoutComponents.EndVerticalGroup();
         }
 
         private void DrawSimpleTable(string[] headers, string[,] data)
         {
-            GUILayout.BeginVertical(GUI.skin.box);
+            layoutComponents.BeginVerticalGroup(GUI.skin.box);
             
-            GUILayout.BeginHorizontal();
+            layoutComponents.BeginHorizontalGroup();
             for (int i = 0; i < headers.Length; i++)
             {
                 GUILayout.Label(headers[i], GUI.skin.label);
             }
-            GUILayout.EndHorizontal();
+            layoutComponents.EndHorizontalGroup();
             
             int rowCount = data.GetLength(0);
             int colCount = data.GetLength(1);
             
             for (int row = 0; row < rowCount; row++)
             {
-                GUILayout.BeginHorizontal();
+                layoutComponents.BeginHorizontalGroup();
                 
                 for (int col = 0; col < colCount; col++)
                 {
@@ -457,29 +459,29 @@ namespace shadcnui.GUIComponents
                     GUILayout.Label(cellValue, GUI.skin.label);
                 }
                 
-                GUILayout.EndHorizontal();
+                layoutComponents.EndHorizontalGroup();
             }
             
-            GUILayout.EndVertical();
+            layoutComponents.EndVerticalGroup();
         }
 
         private void DrawSimpleTable(string[] headers, object[,] data)
         {
-            GUILayout.BeginVertical(GUI.skin.box);
+            layoutComponents.BeginVerticalGroup(GUI.skin.box);
             
-            GUILayout.BeginHorizontal();
+            layoutComponents.BeginHorizontalGroup();
             for (int i = 0; i < headers.Length; i++)
             {
                 GUILayout.Label(headers[i], GUI.skin.label);
             }
-            GUILayout.EndHorizontal();
+            layoutComponents.EndHorizontalGroup();
             
             int rowCount = data.GetLength(0);
             int colCount = data.GetLength(1);
             
             for (int row = 0; row < rowCount; row++)
             {
-                GUILayout.BeginHorizontal();
+                layoutComponents.BeginHorizontalGroup();
                 
                 for (int col = 0; col < colCount; col++)
                 {
@@ -488,10 +490,10 @@ namespace shadcnui.GUIComponents
                     GUILayout.Label(cellText, GUI.skin.label);
                 }
                 
-                GUILayout.EndHorizontal();
+                layoutComponents.EndHorizontalGroup();
             }
             
-            GUILayout.EndVertical();
+            layoutComponents.EndVerticalGroup();
         }
 
         private string[,] FilterTableData(string[,] data, string searchQuery)

--- a/shadcnui/GUIComponents/GUITabsComponents.cs
+++ b/shadcnui/GUIComponents/GUITabsComponents.cs
@@ -8,72 +8,71 @@ namespace shadcnui.GUIComponents
     public class GUITabsComponents
     {
         private GUIHelper guiHelper;
-
+        private GUILayoutComponents layoutComponents;
         public GUITabsComponents(GUIHelper helper)
         {
             guiHelper = helper;
+            layoutComponents = new GUILayoutComponents(helper);
         }
         public int Tabs(string[] tabNames, int selectedIndex, Action<int> onTabChange = null,
-            params GUILayoutOption[] options)
+            int maxLines = 1, params GUILayoutOption[] options)
         {
             if (tabNames == null || tabNames.Length == 0)
                 return selectedIndex;
 
             var styleManager = guiHelper.GetStyleManager();
 
-           
             selectedIndex = Mathf.Clamp(selectedIndex, 0, tabNames.Length - 1);
 
-           
-            GUILayout.BeginHorizontal(styleManager.GetTabsListStyle());
-
             int newSelectedIndex = selectedIndex;
+            int tabsPerLine = (int)Mathf.Ceil((float)tabNames.Length / maxLines);
 
-            for (int i = 0; i < tabNames.Length; i++)
+            for (int line = 0; line < maxLines; line++)
             {
-                bool isActive = i == selectedIndex;
-                GUIStyle triggerStyle = styleManager.GetTabsTriggerStyle(isActive);
+                layoutComponents.BeginHorizontalGroup(styleManager.GetTabsListStyle());
+                for (int i = line * tabsPerLine; i < (line + 1) * tabsPerLine && i < tabNames.Length; i++)
+                {
+                    bool isActive = i == selectedIndex;
+                    GUIStyle triggerStyle = styleManager.GetTabsTriggerStyle(isActive);
 
-               
-                var tabOptions = new List<GUILayoutOption>();
-                tabOptions.Add(GUILayout.Height(Mathf.RoundToInt(36 * guiHelper.uiScale)));
+                    var tabOptions = new List<GUILayoutOption>();
+                    tabOptions.Add(GUILayout.Height(Mathf.RoundToInt(36 * guiHelper.uiScale)));
 
-                if (options != null && options.Length > 0)
-                    tabOptions.AddRange(options);
+                    if (options != null && options.Length > 0)
+                        tabOptions.AddRange(options);
 
 #if IL2CPP
-                bool clicked = GUILayout.Button(tabNames[i] ?? $"Tab {i + 1}", triggerStyle,
-                    (Il2CppReferenceArray<GUILayoutOption>)tabOptions.ToArray());
+                    bool clicked = GUILayout.Button(tabNames[i] ?? $"Tab {i + 1}", triggerStyle,
+                        (Il2CppReferenceArray<GUILayoutOption>)tabOptions.ToArray());
 #else
-                bool clicked = GUILayout.Button(tabNames[i] ?? $"Tab {i + 1}", triggerStyle,
-                    tabOptions.ToArray());
+                    bool clicked = GUILayout.Button(tabNames[i] ?? $"Tab {i + 1}", triggerStyle,
+                        tabOptions.ToArray());
 #endif
 
-                if (clicked && i != selectedIndex)
-                {
-                    newSelectedIndex = i;
-                    onTabChange?.Invoke(i);
-                }
+                    if (clicked && i != selectedIndex)
+                    {
+                        newSelectedIndex = i;
+                        onTabChange?.Invoke(i);
+                    }
 
-               
-                if (i < tabNames.Length - 1)
-                {
-                    GUILayout.Space(2 * guiHelper.uiScale);
+                    if (i < (line + 1) * tabsPerLine - 1 && i < tabNames.Length - 1)
+                    {
+                        layoutComponents.AddSpace(2);
+                    }
                 }
+                layoutComponents.EndHorizontalGroup();
             }
-
-            GUILayout.EndHorizontal();
 
             return newSelectedIndex;
         }
         public void BeginTabContent()
         {
             var styleManager = guiHelper.GetStyleManager();
-            GUILayout.BeginVertical(styleManager.GetTabsContentStyle());
+            layoutComponents.BeginVerticalGroup(styleManager.GetTabsContentStyle());
         }
         public void EndTabContent()
         {
-            GUILayout.EndVertical();
+            layoutComponents.EndVerticalGroup();
         }
         public int TabsWithContent(TabConfig[] tabConfigs, int selectedIndex, Action<int> onTabChange = null)
         {
@@ -111,7 +110,7 @@ namespace shadcnui.GUIComponents
            
             selectedIndex = Mathf.Clamp(selectedIndex, 0, tabNames.Length - 1);
 
-            GUILayout.BeginVertical();
+            layoutComponents.BeginVerticalGroup();
 
             int newSelectedIndex = selectedIndex;
 
@@ -145,11 +144,11 @@ namespace shadcnui.GUIComponents
                
                 if (i < tabNames.Length - 1)
                 {
-                    GUILayout.Space(2 * guiHelper.uiScale);
+                    layoutComponents.AddSpace(2);
                 }
             }
 
-            GUILayout.EndVertical();
+            layoutComponents.EndVerticalGroup();
 
             return newSelectedIndex;
         }

--- a/shadcnui/GUIComponents/GUITextAreaComponents.cs
+++ b/shadcnui/GUIComponents/GUITextAreaComponents.cs
@@ -7,10 +7,12 @@ namespace shadcnui.GUIComponents
     public class GUITextAreaComponents
     {
         private GUIHelper guiHelper;
+        private GUILayoutComponents layoutComponents;
 
         public GUITextAreaComponents(GUIHelper helper)
         {
             guiHelper = helper;
+            layoutComponents = new GUILayoutComponents(helper);
         }
         public string TextArea(string text, TextAreaVariant variant = TextAreaVariant.Default,
             string placeholder = "", bool disabled = false, float minHeight = 60f, int maxLength = -1,
@@ -120,7 +122,7 @@ namespace shadcnui.GUIComponents
             if (!string.IsNullOrEmpty(label))
             {
                 GUILayout.Label(label, styleManager.GetLabelStyle(LabelVariant.Default));
-                GUILayout.Space(4 * guiHelper.uiScale);
+                layoutComponents.AddSpace(4);
             }
 
            
@@ -129,8 +131,8 @@ namespace shadcnui.GUIComponents
            
             if (showCharCount)
             {
-                GUILayout.Space(4 * guiHelper.uiScale);
-                GUILayout.BeginHorizontal();
+                layoutComponents.AddSpace(4);
+                layoutComponents.BeginHorizontalGroup();
                 GUILayout.FlexibleSpace();
 
                 string countText = maxLength > 0 ?
@@ -145,7 +147,7 @@ namespace shadcnui.GUIComponents
                 countStyle.normal.textColor = countColor;
 
                 GUILayout.Label(countText, countStyle);
-                GUILayout.EndHorizontal();
+                layoutComponents.EndHorizontalGroup();
             }
 
             return result;
@@ -169,7 +171,7 @@ namespace shadcnui.GUIComponents
             string result = TextArea(text, variant, placeholder, disabled, height, maxLength, layoutOptions.ToArray());
 
            
-            GUILayout.BeginHorizontal();
+            layoutComponents.BeginHorizontalGroup();
             GUILayout.FlexibleSpace();
 
             var styleManager = guiHelper.GetStyleManager();
@@ -181,7 +183,7 @@ namespace shadcnui.GUIComponents
                 height = height >= maxHeight ? minHeight : height + 20f;
             }
 
-            GUILayout.EndHorizontal();
+            layoutComponents.EndHorizontalGroup();
 
             return result;
         }

--- a/shadcnui/GUIComponents/GUIToggleComponents.cs
+++ b/shadcnui/GUIComponents/GUIToggleComponents.cs
@@ -9,10 +9,12 @@ namespace shadcnui.GUIComponents
     public class GUIToggleComponents
     {
         private GUIHelper guiHelper;
+        private GUILayoutComponents layoutComponents;
 
         public GUIToggleComponents(GUIHelper helper)
         {
             guiHelper = helper;
+            layoutComponents = new GUILayoutComponents(helper);
         }
 
         public void DrawToggle(float windowWidth, string label, ref bool value, Action<bool> onToggle)
@@ -37,24 +39,24 @@ namespace shadcnui.GUIComponents
                 value = !value;
                 onToggle?.Invoke(value);
             }
-            GUILayout.Space(guiHelper.controlSpacing);
+            layoutComponents.AddSpace(guiHelper.controlSpacing);
         }
 
         public bool DrawCheckbox(float windowWidth, string label, ref bool value)
         {
             var styleManager = guiHelper.GetStyleManager();
 #if IL2CPP
-            GUILayout.BeginHorizontal(GUIStyle.none, (Il2CppReferenceArray<GUILayoutOption>)null);
+            layoutComponents.BeginHorizontalGroup(GUIStyle.none, (Il2CppReferenceArray<GUILayoutOption>)null);
             value = GUILayout.Toggle(value, "", (Il2CppReferenceArray<GUILayoutOption>)new GUILayoutOption[] { GUILayout.Width(20) });
             GUILayout.Label(label, styleManager.glowLabelStyle, (Il2CppReferenceArray<GUILayoutOption>)null);
-            GUILayout.EndHorizontal();
+            layoutComponents.EndHorizontalGroup();
 #else
-            GUILayout.BeginHorizontal();
+            layoutComponents.BeginHorizontalGroup();
             value = GUILayout.Toggle(value, "", GUILayout.Width(20));
             GUILayout.Label(label, styleManager.glowLabelStyle);
-            GUILayout.EndHorizontal();
+            layoutComponents.EndHorizontalGroup();
 #endif
-            GUILayout.Space(guiHelper.controlSpacing);
+            layoutComponents.AddSpace(guiHelper.controlSpacing);
             return value;
         }
 
@@ -70,7 +72,7 @@ namespace shadcnui.GUIComponents
                 GUILayout.Label(label, styleManager.glowLabelStyle);
             selected = GUILayout.SelectionGrid(selected, texts, xCount, styleManager.animatedButtonStyle);
 #endif
-            GUILayout.Space(guiHelper.controlSpacing);
+            layoutComponents.AddSpace(guiHelper.controlSpacing);
             return selected;
         }
         public bool Toggle(string text, bool value, ToggleVariant variant = ToggleVariant.Default,
@@ -133,17 +135,17 @@ namespace shadcnui.GUIComponents
             if (horizontal)
             {
 #if IL2CPP
-                GUILayout.BeginHorizontal(GUIStyle.none, (Il2CppReferenceArray<GUILayoutOption>)null);
+                layoutComponents.BeginHorizontalGroup(GUIStyle.none, (Il2CppReferenceArray<GUILayoutOption>)null);
 #else
-                GUILayout.BeginHorizontal();
+                layoutComponents.BeginHorizontalGroup();
 #endif
             }
             else
             {
 #if IL2CPP
-                GUILayout.BeginVertical(GUIStyle.none, (Il2CppReferenceArray<GUILayoutOption>)null);
+                layoutComponents.BeginVerticalGroup(GUIStyle.none, (Il2CppReferenceArray<GUILayoutOption>)null);
 #else
-                GUILayout.BeginVertical();
+                layoutComponents.BeginVerticalGroup();
 #endif
             }
 
@@ -157,15 +159,15 @@ namespace shadcnui.GUIComponents
                 }
 
                 if (horizontal && i < texts.Length - 1)
-                    GUILayout.Space(spacing);
+                    layoutComponents.AddSpace(spacing);
             }
 
             if (horizontal)
-                GUILayout.EndHorizontal();
+                layoutComponents.EndHorizontalGroup();
             else
-                GUILayout.EndVertical();
+                layoutComponents.EndVerticalGroup();
 
-            GUILayout.Space(spacing);
+            layoutComponents.AddSpace(spacing);
 
             return newSelectedIndex;
         }
@@ -179,17 +181,17 @@ namespace shadcnui.GUIComponents
             if (horizontal)
             {
 #if IL2CPP
-                GUILayout.BeginHorizontal(GUIStyle.none, (Il2CppReferenceArray<GUILayoutOption>)null);
+                layoutComponents.BeginHorizontalGroup(GUIStyle.none, (Il2CppReferenceArray<GUILayoutOption>)null);
 #else
-                GUILayout.BeginHorizontal();
+                layoutComponents.BeginHorizontalGroup();
 #endif
             }
             else
             {
 #if IL2CPP
-                GUILayout.BeginVertical(GUIStyle.none, (Il2CppReferenceArray<GUILayoutOption>)null);
+                layoutComponents.BeginVerticalGroup(GUIStyle.none, (Il2CppReferenceArray<GUILayoutOption>)null);
 #else
-                GUILayout.BeginVertical();
+                layoutComponents.BeginVerticalGroup();
 #endif
             }
 
@@ -199,15 +201,15 @@ namespace shadcnui.GUIComponents
                     (value) => onToggleChange?.Invoke(i, value));
 
                 if (horizontal && i < texts.Length - 1)
-                    GUILayout.Space(spacing);
+                    layoutComponents.AddSpace(spacing);
             }
 
             if (horizontal)
-                GUILayout.EndHorizontal();
+                layoutComponents.EndHorizontalGroup();
             else
-                GUILayout.EndVertical();
+                layoutComponents.EndVerticalGroup();
 
-            GUILayout.Space(spacing);
+            layoutComponents.AddSpace(spacing);
 
             return newStates;
         }

--- a/shadcnui/GUIComponents/GUIVisualComponents.cs
+++ b/shadcnui/GUIComponents/GUIVisualComponents.cs
@@ -9,11 +9,13 @@ namespace shadcnui.GUIComponents
     public class GUIVisualComponents
     {
         private GUIHelper guiHelper;
+        private GUILayoutComponents layoutComponents;
         private static float horizontalPadding = 10f;
 
         public GUIVisualComponents(GUIHelper helper)
         {
             guiHelper = helper;
+            layoutComponents = new GUILayoutComponents(helper);
         }
 
         public void DrawProgressBar(float windowWidth, string label, float progress, Color barColor)
@@ -48,7 +50,7 @@ namespace shadcnui.GUIComponents
             }
             GUI.Box(progressRect, "", GUI.skin.box);
 
-            GUILayout.Space(guiHelper.controlSpacing);
+            layoutComponents.AddSpace(guiHelper.controlSpacing);
         }
 
         public void DrawBox(float windowWidth, string content, float height = 30f)
@@ -60,7 +62,7 @@ namespace shadcnui.GUIComponents
 #else
             GUILayout.Box(content, styleManager.animatedInputStyle, GUILayout.Height(height * guiHelper.uiScale));
 #endif
-            GUILayout.Space(guiHelper.controlSpacing);
+            layoutComponents.AddSpace(guiHelper.controlSpacing);
         }
 
         public void DrawSeparator(float windowWidth, float height = 2f)
@@ -83,7 +85,7 @@ namespace shadcnui.GUIComponents
             GUI.backgroundColor = separatorColor;
             GUI.Box(rect, "");
             GUI.backgroundColor = originalColor;
-            GUILayout.Space(guiHelper.controlSpacing);
+            layoutComponents.AddSpace(guiHelper.controlSpacing);
         }
 
         public void RenderInstructions(string text)
@@ -96,17 +98,17 @@ namespace shadcnui.GUIComponents
             instructionStyle.normal.textColor = instructionColor;
 
 #if IL2CPP
-            GUILayout.BeginHorizontal(GUIStyle.none, (Il2CppReferenceArray<GUILayoutOption>)null);
+            layoutComponents.BeginHorizontalGroup(GUIStyle.none, (Il2CppReferenceArray<GUILayoutOption>)null);
             GUILayout.FlexibleSpace();
             GUILayout.Label(text, instructionStyle, (Il2CppReferenceArray<GUILayoutOption>)null);
             GUILayout.FlexibleSpace();
-            GUILayout.EndHorizontal();
+            layoutComponents.EndHorizontalGroup();
 #else
-            GUILayout.BeginHorizontal();
+            layoutComponents.BeginHorizontalGroup();
             GUILayout.FlexibleSpace();
             GUILayout.Label(text, instructionStyle);
             GUILayout.FlexibleSpace();
-            GUILayout.EndHorizontal();
+            layoutComponents.EndHorizontalGroup();
 #endif
         }
     }

--- a/shadcnui/GUIHelper.cs
+++ b/shadcnui/GUIHelper.cs
@@ -79,6 +79,10 @@ namespace shadcnui
         private GUIAvatarComponents avatarComponents;
         private GUISkeletonComponents skeletonComponents;
         private GUITableComponents tableComponents;
+        private GUICalendarComponents calendarComponents;
+        private GUIDropdownMenuComponents dropdownMenuComponents;
+        private GUIPopoverComponents popoverComponents;
+        private GUISelectComponents selectComponents;
         #endregion
 
         #region Public Style Access
@@ -132,6 +136,10 @@ namespace shadcnui
                 avatarComponents = new GUIAvatarComponents(this);
                 skeletonComponents = new GUISkeletonComponents(this);
                 tableComponents = new GUITableComponents(this);
+                calendarComponents = new GUICalendarComponents(this);
+                dropdownMenuComponents = new GUIDropdownMenuComponents(this);
+                popoverComponents = new GUIPopoverComponents(this);
+                selectComponents = new GUISelectComponents(this);
             }
             catch (Exception ex)
             {
@@ -825,11 +833,11 @@ namespace shadcnui
         #endregion
 
         #region Layout Components
-        public Vector2 DrawScrollView(Vector2 scrollPosition, float width, float height, System.Action drawContent)
+        public Vector2 DrawScrollView(Vector2 scrollPosition, System.Action drawContent, params GUILayoutOption[] options)
         {
             try
             {
-                return layoutComponents?.DrawScrollView(scrollPosition, width, height, drawContent) ?? scrollPosition;
+                return layoutComponents?.DrawScrollView(scrollPosition, drawContent, options) ?? scrollPosition;
             }
             catch (Exception ex)
             {
@@ -1140,11 +1148,11 @@ namespace shadcnui
 
         #region Tabs Components
         public int Tabs(string[] tabNames, int selectedIndex, Action<int> onTabChange = null,
-            params GUILayoutOption[] options)
+            int maxLines = 1, params GUILayoutOption[] options)
         {
             try
             {
-                return tabsComponents?.Tabs(tabNames, selectedIndex, onTabChange, options) ?? selectedIndex;
+                return tabsComponents?.Tabs(tabNames, selectedIndex, onTabChange, maxLines, options) ?? selectedIndex;
             }
             catch (Exception ex)
             {
@@ -1470,7 +1478,7 @@ namespace shadcnui
         {
             try
             {
-                return switchComponents?.SwitchWithLabel(label, value, variant, size, onToggle, disabled) ?? value;
+                return switchComponents?.SwitchWithLabel(label, ref value, variant, size, onToggle, disabled) ?? value;
             }
             catch (Exception ex)
             {
@@ -1485,7 +1493,7 @@ namespace shadcnui
         {
             try
             {
-                return switchComponents?.SwitchWithDescription(label, description, value, variant, size,
+                return switchComponents?.SwitchWithDescription(label, description, ref value, variant, size,
                     onToggle, disabled) ?? value;
             }
             catch (Exception ex)
@@ -1531,7 +1539,7 @@ namespace shadcnui
         {
             try
             {
-                return switchComponents?.ValidatedSwitch(text, value, isValid, validationMessage, variant,
+                return switchComponents?.ValidatedSwitch(text, ref value, isValid, validationMessage, variant,
                     size, onToggle, disabled) ?? value;
             }
             catch (Exception ex)
@@ -1547,7 +1555,7 @@ namespace shadcnui
         {
             try
             {
-                return switchComponents?.SwitchWithTooltip(text, value, tooltip, variant, size, onToggle, disabled) ?? value;
+                return switchComponents?.SwitchWithTooltip(text, ref value, tooltip, variant, size, onToggle, disabled) ?? value;
             }
             catch (Exception ex)
             {
@@ -1759,8 +1767,6 @@ namespace shadcnui
                 Debug.LogError("Error drawing alert: " + ex.Message);
             }
         }
-
-        
 
         public void AlertWithIcon(string title, string description, Texture2D icon, AlertVariant variant = AlertVariant.Default,
             AlertType type = AlertType.Info, params GUILayoutOption[] options)
@@ -2040,19 +2046,6 @@ namespace shadcnui
             }
         }
 
-        public void Skeleton(Rect rect, SkeletonVariant variant = SkeletonVariant.Default,
-            SkeletonSize size = SkeletonSize.Default)
-        {
-            try
-            {
-                skeletonComponents?.Skeleton(rect, variant, size);
-            }
-            catch (Exception ex)
-            {
-                Debug.LogError("Error drawing skeleton in rect: " + ex.Message);
-            }
-        }
-
         public void AnimatedSkeleton(float width, float height, SkeletonVariant variant = SkeletonVariant.Default,
             SkeletonSize size = SkeletonSize.Default, params GUILayoutOption[] options)
         {
@@ -2093,12 +2086,12 @@ namespace shadcnui
             }
         }
 
-        public void SkeletonText(int lineCount, float lineHeight = 20f, SkeletonVariant variant = SkeletonVariant.Default,
+        public void SkeletonText(float width, int lineCount, float lineHeight = 20f, SkeletonVariant variant = SkeletonVariant.Default,
             SkeletonSize size = SkeletonSize.Default, params GUILayoutOption[] options)
         {
             try
             {
-                skeletonComponents?.SkeletonText(lineCount, lineHeight, variant, size, options);
+                skeletonComponents?.SkeletonText(width, lineCount, options);
             }
             catch (Exception ex)
             {
@@ -2132,12 +2125,12 @@ namespace shadcnui
             }
         }
 
-        public void SkeletonCard(float width = 300f, float height = 200f, SkeletonVariant variant = SkeletonVariant.Rounded,
-            SkeletonSize size = SkeletonSize.Default, params GUILayoutOption[] options)
+        public void SkeletonCard(float width = 300f, float height = 200f, bool includeHeader = true,
+            bool includeFooter = false, params GUILayoutOption[] options)
         {
             try
             {
-                skeletonComponents?.SkeletonCard(width, height, variant, size, options);
+                skeletonComponents?.SkeletonCard(width, height, includeHeader, includeFooter, options);
             }
             catch (Exception ex)
             {
@@ -2146,12 +2139,11 @@ namespace shadcnui
         }
 
         public void SkeletonTable(int rowCount, int columnCount, float cellWidth = 100f, float cellHeight = 30f,
-            SkeletonVariant variant = SkeletonVariant.Default, SkeletonSize size = SkeletonSize.Default,
             params GUILayoutOption[] options)
         {
             try
             {
-                skeletonComponents?.SkeletonTable(rowCount, columnCount, cellWidth, cellHeight, variant, size, options);
+                skeletonComponents?.SkeletonTable(cellWidth, rowCount, columnCount, cellHeight, 0f, options);
             }
             catch (Exception ex)
             {
@@ -2159,29 +2151,16 @@ namespace shadcnui
             }
         }
 
-        public void SkeletonList(int itemCount, float itemHeight = 60f, SkeletonVariant variant = SkeletonVariant.Rounded,
-            SkeletonSize size = SkeletonSize.Default, params GUILayoutOption[] options)
-        {
-            try
-            {
-                skeletonComponents?.SkeletonList(itemCount, itemHeight, variant, size, options);
-            }
-            catch (Exception ex)
-            {
-                Debug.LogError("Error drawing skeleton list: " + ex.Message);
-            }
-        }
-
-        public void CustomShapeSkeleton(float width, float height, float cornerRadius, Color backgroundColor,
+        public void SkeletonList(int itemCount, float itemHeight = 60f,
             params GUILayoutOption[] options)
         {
             try
             {
-                skeletonComponents?.CustomShapeSkeleton(width, height, cornerRadius, backgroundColor, options);
+                skeletonComponents?.SkeletonList(100f, itemHeight, itemCount, 0f, options);
             }
             catch (Exception ex)
             {
-                Debug.LogError("Error drawing custom shape skeleton: " + ex.Message);
+                Debug.LogError("Error drawing skeleton list: " + ex.Message);
             }
         }
 
@@ -2326,5 +2305,108 @@ namespace shadcnui
             }
         }
         #endregion
+
+        #region Calendar Components
+        public void Calendar()
+        {
+            try
+            {
+                calendarComponents?.Calendar();
+            }
+            catch (Exception ex)
+            {
+                Debug.LogError("Error drawing calendar: " + ex.Message);
+            }
+        }
+        #endregion
+
+        #region DropdownMenu Components
+        public void DropdownMenu(string[] items, Action<int> onItemSelected)
+        {
+            try
+            {
+                dropdownMenuComponents?.DropdownMenu(items, onItemSelected);
+            }
+            catch (Exception ex)
+            {
+                Debug.LogError("Error drawing dropdown menu: " + ex.Message);
+            }
+        }
+
+        public void OpenDropdownMenu()
+        {
+            dropdownMenuComponents?.Open();
+        }
+
+        public void CloseDropdownMenu()
+        {
+            dropdownMenuComponents?.Close();
+        }
+
+        public bool IsDropdownMenuOpen()
+        {
+            return dropdownMenuComponents?.IsOpen ?? false;
+        }
+        #endregion
+
+        #region Popover Components
+        public void Popover(Action content)
+        {
+            try
+            {
+                popoverComponents?.Popover(content);
+            }
+            catch (Exception ex)
+            {
+                Debug.LogError("Error drawing popover: " + ex.Message);
+            }
+        }
+
+        public void OpenPopover()
+        {
+            popoverComponents?.Open();
+        }
+
+        public void ClosePopover()
+        {
+            popoverComponents?.Close();
+        }
+
+        public bool IsPopoverOpen()
+        {
+            return popoverComponents?.IsOpen ?? false;
+        }
+        #endregion
+
+        #region Select Components
+        public int Select(string[] items, int selectedIndex)
+        {
+            try
+            {
+                return selectComponents?.Select(items, selectedIndex) ?? selectedIndex;
+            }
+            catch (Exception ex)
+            {
+                Debug.LogError("Error drawing select: " + ex.Message);
+                return selectedIndex;
+            }
+        }
+
+        public void OpenSelect()
+        {
+            selectComponents?.Open();
+        }
+
+        public void CloseSelect()
+        {
+            selectComponents?.Close();
+        }
+
+        public bool IsSelectOpen()
+        {
+            return selectComponents?.IsOpen ?? false;
+        }
+        #endregion
+
     }
 }

--- a/shadcnui/shadcnui.csproj
+++ b/shadcnui/shadcnui.csproj
@@ -421,12 +421,16 @@
     <Compile Include="GUIComponents\GUIAvatarComponents.cs" />
     <Compile Include="GUIComponents\GUIBadgeComponents.cs" />
     <Compile Include="GUIComponents\GUIButtonComponents.cs" />
+    <Compile Include="GUIComponents\GUICalendarComponents.cs" />
     <Compile Include="GUIComponents\GUICardComponents.cs" />
     <Compile Include="GUIComponents\GUICheckboxComponents.cs" />
+    <Compile Include="GUIComponents\GUIDropdownMenuComponents.cs" />
     <Compile Include="GUIComponents\GUIInputComponents.cs" />
     <Compile Include="GUIComponents\GUILabelComponents.cs" />
     <Compile Include="GUIComponents\GUILayoutComponents.cs" />
+    <Compile Include="GUIComponents\GUIPopoverComponents.cs" />
     <Compile Include="GUIComponents\GUIProgressComponents.cs" />
+    <Compile Include="GUIComponents\GUISelectComponents.cs" />
     <Compile Include="GUIComponents\GUISeparatorComponents.cs" />
     <Compile Include="GUIComponents\GUISkeletonComponents.cs" />
     <Compile Include="GUIComponents\GUISliderComponents.cs" />


### PR DESCRIPTION
This update refactors UI code to consistently use `layoutComponents` instead of `GUILayout` for `BeginHorizontal`, `EndHorizontal`, and `Space`.

\~

### New Components Added

* `GUICalendarComponents`
* `GUIDropdownMenuComponents`
* `GUIPopoverComponents`
* `GUISelectComponents`
